### PR TITLE
Image capture

### DIFF
--- a/camera-stream/README.md
+++ b/camera-stream/README.md
@@ -1,0 +1,106 @@
+# Camera Stream
+
+Allows for a video device to be streamed over Webrtc. Currently the `/dev/video0` device is used by default.
+
+## GStreamer
+
+GStreamer is an open-source multimedia framework that enables the creation of applications for handling video, audio, and other media types. It uses a pipeline-based architecture, where data flows through a series of elements (such as decoders, encoders, filters, and sinks) to process media.
+
+
+
+`gst-launch-1.0` creates a GStreamer pipeline that captures video from a camera and streams it over UDP. Command Breakdown:
+
+- `v4l2src device=/dev/video0`: Captures raw video from the device `/dev/video0` (The webcam or capture card).
+- `'video/x-raw, width=640, height=480, framerate=30/1'`: Specifies the format of the captured video, setting the resolution to 640x480 pixels and the frame rate to 30 frames per second. This resolution can be changed once we know the resolution of the FPV camera.
+- `videoconvert`: Converts the video format to ensure compatibility with the next elements in the pipeline.
+- `vp8enc deadline=1`: Encodes the video in VP8 format with a low latency setting (`deadline=1`).
+- `rtpvp8pay`: Packages the encoded VP8 video into RTP (Real-time Transport Protocol) packets for streaming.
+- `udpsink host=janus port=10000`: Sends the RTP stream via UDP to the host `janus` on port 10000, typically to a server or service like Janus WebRTC server.
+
+This pipeline captures, encodes, and streams video to the Janus service over a specified network protocol. The script is located in `./gstreamer/start_stream.sh`. The script is run when the docker compose is started. 
+
+```sh
+gst-launch-1.0 v4l2src device=/dev/video0 ! \
+  'video/x-raw, width=640, height=480, framerate=30/1' ! \
+  videoconvert ! vp8enc deadline=1 ! \
+  rtpvp8pay ! udpsink host=janus port=10000
+```
+
+## Janus
+Janus is an open-source WebRTC server designed to enable real-time communication (RTC) between web browsers, mobile devices, and other media services. It acts as a general-purpose gateway that supports audio, video, and data streaming, enabling features like video conferencing, live streaming, and peer-to-peer communication.
+
+Janus was choosen because it offers the lowest latency video streaming. This does come with complexity. 
+
+```cfg
+vp8-sample: {
+        type = "rtp"                             
+        id = 1234                               
+        audio = false                           
+        video = true                            
+        videoport = 10000                        
+        videopt = 96                             
+        videocodec = "VP8"                      
+        videofmtp = "profile-level-id=42e01f;packetization-mode=1"  
+        secret = "adminpwd"
+        secret (adjust as needed)
+}
+```
+
+This configuration defines a VP8 video stream for Janus, specifying the details of the stream that will be used to stream video data to Janus. This is located in `./janus/janus.plugin.streaming.jcfg`
+
+- `type = "rtp"`: Indicates that the stream type is RTP (Real-time Transport Protocol), which is typically used for video and audio streaming.
+- `id = 1234`: A unique identifier for the stream, used by Janus to differentiate it from other streams.
+- `description = "VP8 video stream from GStreamer"`: A description of the stream, which provides information about the source or purpose of the stream.
+- `audio = false`: No audio stream is included; the focus is solely on video.
+- `video = true`: Video streaming is enabled.
+- `videoport = 10000`: The port on which Janus listens for incoming video stream data. This should match the port used in the GStreamer pipeline (e.g., `udpsink port=10000`).
+- `videopt = 96`: The RTP payload type assigned to the VP8 stream, which helps in identifying the codec in the RTP packets (should match the codec set in GStreamer).
+- `videocodec = "VP8"`: The codec being used for video encoding, which is VP8 in this case.
+- `videofmtp = "profile-level-id=42e01f;packetization-mode=1"`: Additional VP8-specific parameters for stream negotiation, such as the profile level and packetization mode for proper decoding and delivery.
+- `secret = "adminpwd"`: The authentication secret required to access or configure the stream, ensuring only authorized users can access or modify the stream configuration.
+
+This configuration enables Janus to receive and process an incoming VP8 video stream via RTP (The GStreamer pipeline).
+
+
+## Changing Video Input
+
+Changing the video input is simple. Start by finding the video device that you would like to stream. This can be acheived using the following command:
+
+#### Linux:
+```bash
+v4l2-ctl --list-devices
+```
+##### Example Output:
+```bash
+C922 Pro Stream Webcam (usb-0000:04:00.3-1):
+        /dev/video0
+        /dev/video1
+        /dev/media0
+```
+The device id for this device is: `/dev/video0`
+
+#### Windows/MacOS:
+
+```bash
+ffmpeg -f avfoundation -list_devices true -i ""
+```
+
+#### Updating the docker compose 
+
+Next update the docker compose with the new device id. 
+
+```yml  
+  gstreamer:
+    build:
+      context: ./gstreamer
+      dockerfile: Dockerfile
+    container_name: gstreamer
+    devices:
+      - "<New Device ID>:/dev/video0"
+    depends_on:
+      - janus
+    ports:
+      - '10000:10000/udp'
+    networks:
+      - webrtc_network
+```

--- a/camera-stream/docker-compose.yml
+++ b/camera-stream/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  janus:
+    build:
+      context: ./janus
+      dockerfile: Dockerfile
+    container_name: janus
+    ports:
+      - "8088:8088"
+      - "8089:8089"
+      - "8188:8188"
+      - "8189:8189"
+      - "10001-10200:10001-10200/udp"
+    networks:
+      - webrtc_network
+
+  gstreamer:
+    build:
+      context: ./gstreamer
+      dockerfile: Dockerfile
+    container_name: gstreamer
+    devices:
+      - "/dev/video0:/dev/video0"
+    depends_on:
+      - janus
+    ports:
+      - '10000:10000/udp'
+    networks:
+      - webrtc_network
+
+networks:
+  webrtc_network:
+    driver: bridge

--- a/camera-stream/gstreamer/Dockerfile
+++ b/camera-stream/gstreamer/Dockerfile
@@ -1,0 +1,12 @@
+# Dockerfile for GStreamer
+FROM ubuntu:20.04
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+  gstreamer1.0-tools gstreamer1.0-plugins-base \
+  gstreamer1.0-plugins-good v4l-utils
+
+COPY ./start_stream.sh /opt/gstreamer/start_stream.sh
+
+# Set the entrypoint
+ENTRYPOINT ["bash", "/opt/gstreamer/start_stream.sh"]

--- a/camera-stream/gstreamer/start_stream.sh
+++ b/camera-stream/gstreamer/start_stream.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# GStreamer pipeline to capture webcam video and stream to Janus
+gst-launch-1.0 v4l2src device=/dev/video0 ! \
+  'video/x-raw, width=640, height=480, framerate=30/1' ! \
+  videoconvert ! vp8enc deadline=1 ! \
+  rtpvp8pay ! udpsink host=janus port=10000

--- a/camera-stream/janus/Dockerfile
+++ b/camera-stream/janus/Dockerfile
@@ -1,0 +1,98 @@
+# Use an official Debian as a parent image
+FROM debian:bullseye-slim
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    wget \
+    libmicrohttpd-dev \
+    libjansson-dev \
+    libssl-dev \
+    libsrtp2-dev \
+    libsofia-sip-ua-dev \
+    libglib2.0-dev \
+    libopus-dev \
+    libogg-dev \
+    libcurl4-openssl-dev \
+    liblua5.3-dev \
+    libconfig-dev \
+    pkg-config \
+    gengetopt \
+    libtool \
+    automake \
+    gtk-doc-tools \
+    libnice-dev \
+    libwebsockets-dev \
+    libavutil-dev \
+    libavformat-dev \
+    libavcodec-dev \
+    libavfilter-dev \
+    libavdevice-dev \
+    libavresample-dev \
+    libswscale-dev \
+    libnanomsg-dev \
+    librabbitmq-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install libsrtp with OpenSSL support
+RUN git clone https://github.com/cisco/libsrtp.git /usr/local/src/libsrtp && \
+    cd /usr/local/src/libsrtp && \
+    git checkout v2.4.2 && \
+    ./configure --prefix=/usr/local --enable-openssl && \
+    make shared_library && \
+    make install
+
+# Install usrsctp
+RUN git clone https://github.com/sctplab/usrsctp.git /usr/local/src/usrsctp && \
+    cd /usr/local/src/usrsctp && \
+    ./bootstrap && \
+    ./configure --prefix=/usr/local && \
+    make && \
+    make install
+
+# Update dynamic linker cache
+RUN ldconfig
+
+# Install Janus Gateway
+RUN git clone https://github.com/meetecho/janus-gateway.git /usr/local/src/janus-gateway && \
+    cd /usr/local/src/janus-gateway && \
+    sh autogen.sh && \
+    ./configure --prefix=/opt/janus \
+                --enable-post-processing \
+                --enable-plugin-echotest \
+                --enable-plugin-recordplay \
+                --enable-plugin-sip \
+                --enable-plugin-videocall \
+                --enable-plugin-videoroom \
+                --enable-plugin-voicemail \
+                --enable-plugin-textroom \
+                --enable-plugin-audiobridge \
+                --enable-plugin-nosip \
+                --enable-plugin-streaming \
+                --enable-plugin-lua \
+                --enable-plugin-dtlssrtp \
+                --enable-plugin-srtp \
+                --enable-plugin-usrsctp \
+                --enable-plugin-websockets \
+                --enable-plugin-nanomsg \
+                --enable-plugin-mqtt \
+                --enable-plugin-unixsockets \
+                --enable-plugin-rabbitmq && \
+    make && \
+    make install && \
+    make configs
+
+# Expose necessary ports
+EXPOSE 8088 8089 8188 8189 10000-10200/udp
+
+COPY ./janus.plugin.streaming.jcfg /opt/janus/etc/janus/janus.plugin.streaming.jcfg
+
+# Set the entry point
+ENTRYPOINT ["/opt/janus/bin/janus"]

--- a/camera-stream/janus/README.md
+++ b/camera-stream/janus/README.md
@@ -1,0 +1,5 @@
+## Notes on janus docker compose:
+
+### libsrtp compilation with OpenSSL support
+
+The default apt package for libsrtp does not have the `--enable-openssl` included. Janus requires this flag or errors will be thrown. Therefore the package must be compiled at build time. 

--- a/camera-stream/janus/janus.plugin.streaming.jcfg
+++ b/camera-stream/janus/janus.plugin.streaming.jcfg
@@ -1,0 +1,12 @@
+vp8-sample: {
+        type = "rtp"                             # Stream type is RTP
+        id = 1234                                # Unique stream ID
+        description = "VP8 video stream from GStreamer"  # Description of the stream
+        audio = false                            # No audio stream
+        video = true                             # Video stream is enabled
+        videoport = 10000                        # Port that Janus listens on for the stream
+        videopt = 96                             # Payload type for VP8 stream (this should match GStreamer)
+        videocodec = "VP8"                       # Codec being used for video (VP8)
+        videofmtp = "profile-level-id=42e01f;packetization-mode=1"  # VP8 specific parameters
+        secret = "adminpwd"                      # Authentication secret (adjust as needed)
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,12 +18,15 @@
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
         "google-map-react": "^2.2.1",
-        "next": "14.2.3",
+        "janus-gateway": "^1.3.1",
+        "jquery": "^3.7.1",
+        "next": "^14.2.24",
         "react": "^18",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18",
         "react-google-autocomplete": "^2.7.3",
-        "react-redux": "^9.1.1"
+        "react-redux": "^9.1.1",
+        "webrtc-adapter": "^9.0.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -378,9 +381,10 @@
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "node_modules/@next/env": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.24.tgz",
+      "integrity": "sha512-LAm0Is2KHTNT6IT16lxT+suD0u+VVfYNQqM+EJTKuFRRuY2z+zj01kueWXPCxbMBDt0B5vONYzabHGUNbZYAhA==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.3",
@@ -392,12 +396,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
-      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.24.tgz",
+      "integrity": "sha512-7Tdi13aojnAZGpapVU6meVSpNzgrFwZ8joDcNS8cJVNuP3zqqrLqeory9Xec5TJZR/stsGJdfwo8KeyloT3+rQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -407,12 +412,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.24.tgz",
+      "integrity": "sha512-lXR2WQqUtu69l5JMdTwSvQUkdqAhEWOqJEYUQ21QczQsAlNOW2kWZCucA6b3EXmPbcvmHB1kSZDua/713d52xg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -422,12 +428,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.24.tgz",
+      "integrity": "sha512-nxvJgWOpSNmzidYvvGDfXwxkijb6hL9+cjZx1PVG6urr2h2jUqBALkKjT7kpfurRWicK6hFOvarmaWsINT1hnA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -437,12 +444,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.24.tgz",
+      "integrity": "sha512-PaBgOPhqa4Abxa3y/P92F3kklNPsiFjcjldQGT7kFmiY5nuFn8ClBEoX8GIpqU1ODP2y8P6hio6vTomx2Vy0UQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -452,12 +460,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
-      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.24.tgz",
+      "integrity": "sha512-vEbyadiRI7GOr94hd2AB15LFVgcJZQWu7Cdi9cWjCMeCiUsHWA0U5BkGPuoYRnTxTn0HacuMb9NeAmStfBCLoQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -467,12 +476,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
-      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.24.tgz",
+      "integrity": "sha512-df0FC9ptaYsd8nQCINCzFtDWtko8PNRTAU0/+d7hy47E0oC17tI54U/0NdGk7l/76jz1J377dvRjmt6IUdkpzQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -482,12 +492,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.24.tgz",
+      "integrity": "sha512-ZEntbLjeYAJ286eAqbxpZHhDFYpYjArotQ+/TW9j7UROh0DUmX7wYDGtsTPpfCV8V+UoqHBPU7q9D4nDNH014Q==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -497,12 +508,13 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.24.tgz",
+      "integrity": "sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -512,12 +524,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.24.tgz",
+      "integrity": "sha512-cXcJ2+x0fXQ2CntaE00d7uUH+u1Bfp/E0HsNQH79YiLaZE5Rbm7dZzyAYccn3uICM7mw+DxoMqEfGXZtF4Fgaw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3600,6 +3613,28 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/janus-gateway": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/janus-gateway/-/janus-gateway-1.3.1.tgz",
+      "integrity": "sha512-VyVMNVFOjo9DDvj2rNyOaPC+Re3yyWJAVZPx8zMQNz9bxJNmaLiury7spNTLNfccKN2PONaMgR1t69+Jjr0iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "webrtc-adapter": "8.2.3"
+      }
+    },
+    "node_modules/janus-gateway/node_modules/webrtc-adapter": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-8.2.3.tgz",
+      "integrity": "sha512-gnmRz++suzmvxtp3ehQts6s2JtAGPuDPjA1F3a9ckNpG1kYdYuHWYpazoAnL9FS5/B21tKlhkorbdCXat0+4xQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3608,6 +3643,12 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3929,11 +3970,12 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
-      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.24.tgz",
+      "integrity": "sha512-En8VEexSJ0Py2FfVnRRh8gtERwDRaJGNvsvad47ShkC2Yi8AXQPXEA2vKoDJlGFSj5WE5SyF21zNi4M5gyi+SQ==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.3",
+        "@next/env": "14.2.24",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -3948,15 +3990,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.3",
-        "@next/swc-darwin-x64": "14.2.3",
-        "@next/swc-linux-arm64-gnu": "14.2.3",
-        "@next/swc-linux-arm64-musl": "14.2.3",
-        "@next/swc-linux-x64-gnu": "14.2.3",
-        "@next/swc-linux-x64-musl": "14.2.3",
-        "@next/swc-win32-arm64-msvc": "14.2.3",
-        "@next/swc-win32-ia32-msvc": "14.2.3",
-        "@next/swc-win32-x64-msvc": "14.2.3"
+        "@next/swc-darwin-arm64": "14.2.24",
+        "@next/swc-darwin-x64": "14.2.24",
+        "@next/swc-linux-arm64-gnu": "14.2.24",
+        "@next/swc-linux-arm64-musl": "14.2.24",
+        "@next/swc-linux-x64-gnu": "14.2.24",
+        "@next/swc-linux-x64-musl": "14.2.24",
+        "@next/swc-win32-arm64-msvc": "14.2.24",
+        "@next/swc-win32-ia32-msvc": "14.2.24",
+        "@next/swc-win32-x64-msvc": "14.2.24"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -5445,6 +5487,12 @@
         "compute-scroll-into-view": "^3.0.2"
       }
     },
+    "node_modules/sdp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.0.tgz",
+      "integrity": "sha512-d7wDPgDV3DDiqulJjKiV2865wKsJ34YI+NDREbm+FySq6WuKOikwyNQcm+doLAZ1O6ltdO0SeKle2xMpN3Brgw==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -6245,6 +6293,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.1.tgz",
+      "integrity": "sha512-1AQO+d4ElfVSXyzNVTOewgGT/tAomwwztX/6e3totvyyzXPvXIIuUUjAmyZGbKBKbZOXauuJooZm3g6IuFuiNQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -19,12 +19,14 @@
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "google-map-react": "^2.2.1",
-    "next": "14.2.3",
+    "jquery": "^3.7.1",
+    "next": "^14.2.24",
     "react": "^18",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18",
     "react-google-autocomplete": "^2.7.3",
-    "react-redux": "^9.1.1"
+    "react-redux": "^9.1.1",
+    "webrtc-adapter": "^9.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/client/src/app/embr-details/page.tsx
+++ b/client/src/app/embr-details/page.tsx
@@ -8,6 +8,8 @@ import { generateRandomThermalTemperature } from '@/utils/generateRandomThermalT
 import InfoDetails from '@/components/FleetDetails/InfoDetails';
 import ModelDetails from '@/components/FleetDetails/ModelDetails';
 import Link from 'next/link';
+import JanusStreaming from '@/components/VideoStream';
+
 
 const EmbrDetails = () => {
     return (
@@ -16,7 +18,7 @@ const EmbrDetails = () => {
                 <FleetTitle title={"TEST"}/>
                 <BatteryIndicatorComponent level={18}/>
                 <InfoDetails/>
-                <ModelDetails/>
+                <JanusStreaming></JanusStreaming>
             </div>
             <div className="grid grid-cols-2 grid-rows-2 gap-4 ml-[40px] pt-[2.5vh] pb-[2.5vh]">
                 <RealTimeChart 

--- a/client/src/components/FleetBar/index.tsx
+++ b/client/src/components/FleetBar/index.tsx
@@ -4,15 +4,40 @@ import { FleetItemType } from '@/types/fleet.type';
 
 function FleetBar({ fleets, activeFleet, disabled, setActiveFleet }: { fleets: FleetItemType[]; activeFleet: string | number | null; disabled: boolean; setActiveFleet: React.Dispatch<React.SetStateAction<string | number | null>> }) {
     return (
-        <div className="flex flex-col gap-y-2.5">
-            {fleets.length > 0 ? (
-                fleets.map((fleet) => (
-                    <Item key={fleet.id} fleet={fleet} disabled={disabled} activeFleet={activeFleet} setActiveFleet={setActiveFleet} />
-                ))
-            ) : (
-                <p className="text-gray-500">No fleets available.</p>
-            )}
+        <div className="absolute py-[30px] px-[30px] flex flex-col gap-y-2.5 items-start z-[10]">
+            <div className="flex flex-col gap-y-2.5">
+                {fleets.length > 0 ? (
+                    fleets.map((fleet) => (
+                        <Item key={fleet.id} fleet={fleet} disabled={disabled} activeFleet={activeFleet}
+                              setActiveFleet={setActiveFleet}/>
+                    ))
+                ) : (
+                    <p className="text-gray-500">No fleets available.</p>
+                )}
+            </div>
+
+            <div className="flex justify-start items-center gap-x-1">
+                <button
+                    disabled
+                    className="left-[35px] text-[12px] leading-[15px] px-2 py-0.5 rounded-[22px] bg-white"
+                >
+                    Edit
+                </button>
+                <button
+                    disabled
+                    className="left-[35px] px-2 py-0.5 text-[12px] leading-[15px] rounded-[22px] bg-white"
+                >
+                    Create
+                </button>
+                <button
+                    disabled
+                    className="left-[35px] px-2 py-0.5 text-[12px] leading-[15px] rounded-[22px] bg-white"
+                >
+                    Delete
+                </button>
+            </div>
         </div>
+
     );
 }
 

--- a/client/src/components/GoogleMap.tsx
+++ b/client/src/components/GoogleMap.tsx
@@ -6,36 +6,20 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Dropdown, MenuProps } from "antd";
 import {
   useJsApiLoader,
-  GoogleMap as GoogleMapReact,
+  GoogleMap as GoogleMapReact, GoogleMap,
 } from "@react-google-maps/api";
-
 import FleetBar from "./FleetBar";
-import Search from "./Search";
-import Stats from "./Stats";
-import ToggleSwitch from "./ToggleSwitch";
-import ZoomControl from "./ZoomControl";
 import MissionCreate from "./MissionControls/MissionCreate";
-
-import homeImage from "../../public/home.png";
-import logo from "../../public/white_logo.svg";
 import { useAppDispatch, useAppSelector } from "@/redux/hooks";
-import { getIsLoggedIn } from "@/redux/logging/selectors";
-import { setIsLoggedIn } from "@/redux/logging/slice";
 
 // types/interfaces
-import { CoordinatesType } from "@/types/coordinate.type";
 import { MissionType } from "@/types/mission.type";
-import { FleetItemType } from "@/types/fleet.type";
-import { RobotType } from "@/types/robot.type";
-
-// constants
-import { RobotStateType } from "@/constants/robotConstants";
 
 // custom hooks
 import { useFleetData } from "@/hooks/useFleetData";
-import Login from "./login";
-import DrawBot from "./DrawBot";
 import MapDrawUtils from "@/utils/MapDrawUtils";
+import MapTools from "@/components/MapTools";
+import EmbrDetails from "@/app/embr-details/page";
 
 /*
   Main TODO's: 
@@ -129,13 +113,12 @@ const CustomGoogleMap: React.FC = () => {
   const dispatch = useAppDispatch();
   const [map, setMap] = useState<google.maps.Map | null>(null);
   const [activeFleet, setActiveFleet] = useState<string | number | null>(null);
-  const [activeMissionCreate, setActiveMissionCreate] =
-    useState<boolean>(false);
+  const [activeMissionCreate, setActiveMissionCreate] = useState<boolean>(false);
+  const [cancelDrawing, setCancelDrawing] = useState<any>();
+  const [newMission, setNewMission] = useState<MissionType>(newMissionTemplate);
   const [satelliteView, setSatelliteView] = useState<boolean>(false);
   const [zoomLevel, setZoomLevel] = useState<number>(zoom);
-  const [cancelDrawing, setCancelDrawing] = useState<any>();
-  const [newMission, setNewMission] =
-    useState<MissionType>(newMissionTemplate);
+  const [mapWidth, setMapWidth] = useState(66.67);
 
   const { fleets, bots, loading, error } = useFleetData();
 
@@ -458,13 +441,7 @@ const CustomGoogleMap: React.FC = () => {
 
   }
 
-  const handleZoomIn = () => {
-    setZoomLevel((prevZoomLevel) => Math.min(prevZoomLevel + 1, 21)); // Google Maps API allows a max zoom of 21
-  };
 
-  const handleZoomOut = () => {
-    setZoomLevel((prevZoomLevel) => Math.max(prevZoomLevel - 1, 0)); // Google Maps API allows a min zoom of 0
-  };
 
   const handleMissionClick: MenuProps["onClick"] = ({ key }) => {
     setActiveFleet(null);
@@ -496,59 +473,45 @@ const CustomGoogleMap: React.FC = () => {
     );
   }
 
+  const handleResizeStart = (e: React.MouseEvent | React.TouchEvent) => {
+    const startX = "touches" in e ? e.touches[0].clientX : e.clientX;
+    const startWidth = mapWidth;
+
+    const onMove = (event: MouseEvent | TouchEvent) => {
+      const clientX = "touches" in event ? event.touches[0].clientX : event.clientX;
+      const deltaX = clientX - startX;
+      const newWidth = Math.min(Math.max(startWidth + (deltaX / window.innerWidth) * 100, 30), 70);
+      setMapWidth(newWidth);
+    };
+
+    const onEnd = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onEnd);
+      window.removeEventListener("touchmove", onMove);
+      window.removeEventListener("touchend", onEnd);
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onEnd);
+    window.addEventListener("touchmove", onMove);
+    window.addEventListener("touchend", onEnd);
+  };
 
   // Display map page
   return (
     <>
-      {/* Fleet Bar */}
-      <div className="absolute py-[30px] px-[30px] flex flex-col gap-y-2.5 items-start z-[10]">
-        <FleetBar
-          fleets={fleets}
-          activeFleet={activeFleet}
-          setActiveFleet={setActiveFleet}
-          disabled={activeMissionCreate}
-        />
-        <div className="flex justify-start items-center gap-x-1">
-          <button
-            disabled
-            className="left-[35px] text-[12px] leading-[15px] px-2 py-0.5 rounded-[22px] bg-white"
-          >
-            Edit
-          </button>
-          <button
-            disabled
-            className="left-[35px] px-2 py-0.5 text-[12px] leading-[15px] rounded-[22px] bg-white"
-          >
-            Create
-          </button>
-          <button
-            disabled
-            className="left-[35px] px-2 py-0.5 text-[12px] leading-[15px] rounded-[22px] bg-white"
-          >
-            Delete
-          </button>
-        </div>
-      </div>
+      <FleetBar
+        fleets={fleets}
+        activeFleet={activeFleet}
+        setActiveFleet={setActiveFleet}
+        disabled={activeMissionCreate}
+      />
 
       {/* Map tools */}
-      <div className="absolute py-[30px] px-[30px] bottom-5 right-5 flex flex-col flex-end justify-end float-right items-end gap-[5px] z-[10]">
-        <div className="flex items-center">
-          <span
-            className={`${satelliteView &&
-              "text-white bg-black bg-opacity-50 px-2 py-1 rounded shadow"
-              } text-sm font-medium text-gray-700 mr-2`}
-          >
-            Satellite View:
-          </span>
-          <ToggleSwitch
-            enabled={satelliteView}
-            setEnabled={setSatelliteView}
-          />
-        </div>
-        <div className="flex items-center float-right">
-          <ZoomControl onZoomIn={handleZoomIn} onZoomOut={handleZoomOut} />
-        </div>
-      </div>
+      <MapTools
+        satelliteValue={satelliteView}
+        onSatelliteViewChange={setSatelliteView}
+      />
 
       {/* Top Right Bar */}
       <div className="absolute py-[30px] px-[30px] right-[0] flex flex-col gap-y-[36px] items-end max-w-[400px] z-[10]">
@@ -569,7 +532,7 @@ const CustomGoogleMap: React.FC = () => {
                 <Dropdown
                   menu={{ items, onClick: handleMissionClick }}
                   align={{ offset: [60, -26] }}
-                  placement="bottomLeft"
+                  placement="bottomRight"
                   className="cursor-pointer left-[35px] px-3.5 py-1 rounded-[22px] text-[15px] leading-[18px] bg-white select-none"
                   trigger={["click"]}
                 >
@@ -577,7 +540,7 @@ const CustomGoogleMap: React.FC = () => {
                 </Dropdown>
               </div>
               {
-                // TODO: implement this once the mission logic is in place 
+                // TODO: implement this once the mission logic is in place
                 //  - define table schema for a mission including a way to encode the area, define connection between a fleet and a mission
                 /* <Stats
                   missions={
@@ -605,18 +568,42 @@ const CustomGoogleMap: React.FC = () => {
       </div>
 
       {/* Map */}
-      <GoogleMapReact
-        options={mapOptions}
-        mapContainerClassName="absolute w-screen h-screen relative flex justify-start items-start overflow-hidden z-[0]"
-        center={ubcoCoorations}
-        zoom={zoom}
-        onLoad={onLoad}
-        onUnmount={onUnmount}
-        onZoomChanged={() => {
-          if (map) setZoomLevel(map.getZoom() || zoom);
-        }}
-      >
-      </GoogleMapReact>
+      <div className="flex h-screen max-w-screen max-h-screen overflow-hidden">
+        <div className="h-full" style={{ width: `${activeFleet !== null ? mapWidth : '100'}%` }}>
+          <GoogleMap
+              options={mapOptions}
+              mapContainerClassName="h-screen w-full"
+              center={ubcoCoorations}
+              zoom={zoom}
+              onLoad={onLoad}
+              onUnmount={onUnmount}
+              onZoomChanged={() => {
+                if (map) setZoomLevel(map.getZoom() || zoom);
+              }}
+          />
+        </div>
+
+        {/* Resizable Slider */}
+        {activeFleet !== null ? (
+            <div
+                className="w-2 bg-gray-400 cursor-ew-resize"
+                onMouseDown={handleResizeStart}
+                onTouchStart={handleResizeStart}
+            ></div>
+        ) : (
+            <></>
+        )}
+
+        {/* Split screen to show bot statistics */}
+        {activeFleet !== null ? (
+            <div className="h-full max-h-lvh p-4 bg-gray-100 overflow-y-auto" style={{ width: `${100 - mapWidth}%` }}>
+              <EmbrDetails></EmbrDetails>
+            </div>
+        ) : (
+            <></>
+        )}
+
+      </div>
     </>
   );
 };

--- a/client/src/components/MapTools/index.tsx
+++ b/client/src/components/MapTools/index.tsx
@@ -1,0 +1,30 @@
+import ToggleSwitch from "@/components/ToggleSwitch";
+import ZoomControl from "@/components/ZoomControl";
+import React, {useState} from "react";
+
+
+
+
+const MapTools: React.FC<{ satelliteValue: boolean; onSatelliteViewChange: (val: boolean) => void  }> = ({ satelliteValue, onSatelliteViewChange }) => {
+
+    return (
+        <div
+            className="absolute py-[30px] px-[30px] bottom-5 left-5 flex flex-col flex-end justify-end float-right items-end gap-[5px] z-[10]">
+            <div className="flex items-center">
+          <span
+              className={`${satelliteValue &&
+              "text-white bg-black bg-opacity-50 px-2 py-1 rounded shadow"
+              } text-sm font-medium text-gray-700 mr-2`}
+          >
+            Satellite View:
+          </span>
+                <ToggleSwitch
+                    enabled={satelliteValue}
+                    setEnabled={onSatelliteViewChange}
+                />
+            </div>
+        </div>
+    )
+}
+
+export default MapTools;

--- a/client/src/components/VideoStream/index.jsx
+++ b/client/src/components/VideoStream/index.jsx
@@ -1,0 +1,198 @@
+import React, { useEffect, useRef, useState } from "react";
+import $ from 'jquery';
+import Janus from "./janus.js";
+import adapter from 'webrtc-adapter';
+window.adapter = adapter;
+
+
+const JanusStreaming = () => {
+
+  var janus = null;
+  var streaming = null;
+  var opaqueId = "streamingtest-" + Janus.randomString(12);
+
+  var bitrateTimer = null;
+  var selectedStream = null;
+
+  useEffect(() => {
+    // Initialize the library (all console debuggers enabled)
+    Janus.init({
+      debug: "all", callback: function () {
+        // Make sure the browser supports WebRTC
+        if (!Janus.isWebrtcSupported()) {
+          alert("No WebRTC support... ");
+          return;
+        }
+        // Create session
+        janus = new Janus(
+          {
+            server: "ws://localhost:8188",   //enter your janus gateway IP address
+            success: function () {
+              // Attach to streaming plugin
+              janus.attach(
+                {
+                  plugin: "janus.plugin.streaming",
+                  opaqueId: opaqueId,
+                  success: function (pluginHandle) {
+                    $('#watch').html("Watch").click(startStream);
+                    streaming = pluginHandle;
+                    Janus.log("Plugin attached! (" + streaming.getPlugin() + ", id=" + streaming.getId() + ")");
+                    //get available streams and select the one we need
+                    updateStreamsList();
+                  },
+                  error: function (error) {
+                    Janus.error("  -- Error attaching plugin... ", error);
+                    // alert("Error attaching plugin... " + error);
+                  },
+                  onmessage: function (msg, jsep) {
+                    Janus.debug(" ::: Got a message :::");
+                    Janus.debug(msg);
+                    var result = msg["result"];
+                    if (result !== null && result !== undefined) {
+                      if (result["status"] !== undefined && result["status"] !== null) {
+                        var status = result["status"];
+                        if (status === 'starting')
+                          Janus.log("Starting, please wait...");
+                        else if (status === 'started')
+                          Janus.log("Started");
+                        else if (status === 'stopped')
+                          stopStream();
+                      }
+                    } else if (msg["error"] !== undefined && msg["error"] !== null) {
+                      alert(msg["error"]);
+                      stopStream();
+                      return;
+                    }
+                    if (jsep !== undefined && jsep !== null) {
+                      Janus.debug("Handling SDP as well...");
+                      Janus.debug(jsep);
+                      // Offer from the plugin, let's answer
+                      streaming.createAnswer(
+                        {
+                          jsep: jsep,
+                          media: { audioSend: false, videoSend: false },	// We want recvonly audio/video
+                          success: function (jsep) {
+                            Janus.debug("Got SDP!");
+                            Janus.debug(jsep);
+                            var body = { "request": "start" };
+                            streaming.send({ "message": body, "jsep": jsep });
+                            $('#watch').html("Stop").click(stopStream);
+                          },
+                          error: function (error) {
+                            Janus.error("WebRTC error:", error);
+                            alert("WebRTC error... " + JSON.stringify(error));
+                          }
+                        });
+                    }
+                  },
+                  onremotestream: function (stream) {
+                    Janus.debug(" ::: Got a remote stream :::");
+                    Janus.debug(stream);
+                    if ($('#remotevideo').length === 0) {
+                      $('#stream').append('<video class="rounded centered" id="remotevideo" width=640 height=480 autoplay/>');
+                      // Show the stream and hide the spinner when we get a playing event
+                      $("#remotevideo").on("playing", function () {
+                        Janus.log("playng");
+                        var videoTracks = stream.getVideoTracks();
+                        if (videoTracks === null || videoTracks === undefined || videoTracks.length === 0) {
+                          alert("no videotraks ?!?");
+                          return;
+                        }
+                      });
+                    }
+                    Janus.attachMediaStream($('#remotevideo').get(0), stream);
+                    var videoTracks = stream.getVideoTracks();
+                    if (videoTracks === null || videoTracks === undefined || videoTracks.length === 0) {
+                      // No remote video
+                      alert("No remote video available!");
+                    }
+                    if (videoTracks && videoTracks.length &&
+                      (Janus.webRTCAdapter.browserDetails.browser === "chrome" ||
+                        Janus.webRTCAdapter.browserDetails.browser === "firefox" ||
+                        Janus.webRTCAdapter.browserDetails.browser === "safari")) {
+                      bitrateTimer = setInterval(function () {
+                        Janus.debug("Current bitrate is " + streaming.getBitrate());
+                      }, 1000);
+                    }
+                  },
+                  oncleanup: function () {
+                    Janus.log(" ::: Got a cleanup notification :::");
+                    alert("streaming cleanup");
+                    $('#remotevideo').remove();
+                    if (bitrateTimer !== null && bitrateTimer !== undefined)
+                      clearInterval(bitrateTimer);
+                    bitrateTimer = null;
+                    $('#watch').html("Watch").click(startStream);
+                  }
+                });
+            },
+            error: function (error) {
+              Janus.error(error);
+              alert(error, function () {
+                window.location.reload();
+              });
+            },
+            destroyed: function () {
+              window.location.reload();
+            }
+          });
+      }
+    });
+  }, []);
+
+  function updateStreamsList() {
+    var body = { "request": "list" };
+    Janus.debug("Sending message (" + JSON.stringify(body) + ")");
+    streaming.send({
+      "message": body, success: function (result) {
+        if (result === null || result === undefined) {
+          alert("Got no response to our query for available streams");
+          return;
+        }
+        if (result["list"] !== undefined && result["list"] !== null) {
+          var list = result["list"];
+          Janus.log("Got a list of available streams");
+          Janus.debug(list);
+          for (var mp in list) {
+            Janus.debug("  >> [" + list[mp]["id"] + "] " + list[mp]["description"] + " (" + list[mp]["type"] + ")");
+          }
+          selectedStream = list[0]["id"];
+        }
+      }
+    });
+  }
+
+  function startStream() {
+    $('#watch').off();
+    Janus.log("Selected video id #" + selectedStream);
+    if (selectedStream === undefined || selectedStream === null) {
+      alert("unselected stream");
+      return;
+    }
+    var body = { "request": "watch", id: parseInt(selectedStream) };
+    streaming.send({ "message": body });
+    // No remote video yet
+    Janus.log("starting stream");
+  }
+
+  function stopStream() {
+    $('#watch').off();
+    var body = { "request": "stop" };
+    streaming.send({ "message": body });
+    streaming.hangup();
+    if (bitrateTimer !== null && bitrateTimer !== undefined)
+      clearInterval(bitrateTimer);
+    bitrateTimer = null;
+  }
+
+  return (
+    <div id="streams">
+      <button id="watch">Wait..</button>
+      <div>
+        <div id="stream"></div>
+      </div>
+    </div>
+  );
+};
+
+export default JanusStreaming;

--- a/client/src/components/VideoStream/janus.js
+++ b/client/src/components/VideoStream/janus.js
@@ -1,0 +1,3061 @@
+/*
+	The MIT License (MIT)
+
+	Copyright (c) 2016 Meetecho
+
+	Permission is hereby granted, free of charge, to any person obtaining
+	a copy of this software and associated documentation files (the "Software"),
+	to deal in the Software without restriction, including without limitation
+	the rights to use, copy, modify, merge, publish, distribute, sublicense,
+	and/or sell copies of the Software, and to permit persons to whom the
+	Software is furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included
+	in all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+	THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+	OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+	ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+	OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// List of sessions
+Janus.sessions = {};
+
+// Screensharing Chrome Extension ID
+Janus.extensionId = "hapfgfdkleiggjjpfpenajgdnfckjpaj";
+Janus.isExtensionEnabled = function() {
+	if(window.navigator.userAgent.match('Chrome')) {
+		var chromever = parseInt(window.navigator.userAgent.match(/Chrome\/(.*) /)[1], 10);
+		var maxver = 33;
+		if(window.navigator.userAgent.match('Linux'))
+			maxver = 35;	// "known" crash in chrome 34 and 35 on linux
+		if(chromever >= 26 && chromever <= maxver) {
+			// Older versions of Chrome don't support this extension-based approach, so lie
+			return true;
+		}
+		return Janus.checkJanusExtension();
+	} else {
+		// Firefox of others, no need for the extension (but this doesn't mean it will work)
+		return true;
+	}
+};
+
+Janus.useDefaultDependencies = function (deps) {
+	var f = (deps && deps.fetch) || fetch;
+	var p = (deps && deps.Promise) || Promise;
+	var socketCls = (deps && deps.WebSocket) || WebSocket;
+	return {
+		newWebSocket: function(server, proto) { return new socketCls(server, proto); },
+		isArray: function(arr) { return Array.isArray(arr); },
+		checkJanusExtension: function() { return document.querySelector('#janus-extension-installed') !== null; },
+		webRTCAdapter: (deps && deps.adapter) || adapter,
+		httpAPICall: function(url, options) {
+			var fetchOptions = {
+				method: options.verb,
+				headers: {
+					'Accept': 'application/json, text/plain, */*'
+				},
+				cache: 'no-cache'
+			};
+			if(options.verb === "POST") {
+				fetchOptions.headers['Content-Type'] = 'application/json';
+			}
+			if(options.withCredentials !== undefined) {
+				fetchOptions.credentials = options.withCredentials === true ? 'include' : (options.withCredentials ? options.withCredentials : 'omit');
+			}
+			if(options.body !== undefined) {
+				fetchOptions.body = JSON.stringify(options.body);
+			}
+
+			var fetching = f(url, fetchOptions).catch(function(error) {
+				return p.reject({message: 'Probably a network error, is the gateway down?', error: error});
+			});
+
+			/*
+			 * fetch() does not natively support timeouts.
+			 * Work around this by starting a timeout manually, and racing it agains the fetch() to see which thing resolves first.
+			 */
+
+			if(options.timeout !== undefined) {
+				var timeout = new p(function(resolve, reject) {
+					var timerId = setTimeout(function() {
+						clearTimeout(timerId);
+						return reject({message: 'Request timed out', timeout: options.timeout});
+					}, options.timeout);
+				});
+				fetching = p.race([fetching,timeout]);
+			}
+
+			fetching.then(function(response) {
+				if(response.ok) {
+					if(typeof(options.success) === typeof(Janus.noop)) {
+						return response.json().then(function(parsed) {
+							options.success(parsed);
+						}).catch(function(error) {
+							return p.reject({message: 'Failed to parse response body', error: error, response: response});
+						});
+					}
+				}
+				else {
+					return p.reject({message: 'API call failed', response: response});
+				}
+			}).catch(function(error) {
+				if(typeof(options.error) === typeof(Janus.noop)) {
+					options.error(error.message || '<< internal error >>', error);
+				}
+			});
+
+			return fetching;
+		}
+	}
+};
+
+Janus.useOldDependencies = function (deps) {
+	var jq = (deps && deps.jQuery) || jQuery;
+	var socketCls = (deps && deps.WebSocket) || WebSocket;
+	return {
+		newWebSocket: function(server, proto) { return new socketCls(server, proto); },
+		isArray: function(arr) { return jq.isArray(arr); },
+		checkJanusExtension: function() { return jq('#janus-extension-installed').length > 0; },
+		webRTCAdapter: (deps && deps.adapter) || adapter,
+		httpAPICall: function(url, options) {
+			var payload = options.body !== undefined ? {
+				contentType: 'application/json',
+				data: JSON.stringify(options.body)
+			} : {};
+			var credentials = options.withCredentials !== undefined ? {xhrFields: {withCredentials: options.withCredentials}} : {};
+
+			return jq.ajax(jq.extend(payload, credentials, {
+				url: url,
+				type: options.verb,
+				cache: false,
+				dataType: 'json',
+				async: options.async,
+				timeout: options.timeout,
+				success: function(result) {
+					if(typeof(options.success) === typeof(Janus.noop)) {
+						options.success(result);
+					}
+				},
+				error: function(xhr, status, err) {
+					if(typeof(options.error) === typeof(Janus.noop)) {
+						options.error(status, err);
+					}
+				}
+			}));
+		},
+	};
+};
+
+Janus.noop = function() {};
+
+// Initialization
+Janus.init = function(options) {
+	options = options || {};
+	options.callback = (typeof options.callback == "function") ? options.callback : Janus.noop;
+	if(Janus.initDone === true) {
+		// Already initialized
+		options.callback();
+	} else {
+		if(typeof console == "undefined" || typeof console.log == "undefined")
+			console = { log: function() {} };
+		// Console logging (all debugging disabled by default)
+		Janus.trace = Janus.noop;
+		Janus.debug = Janus.noop;
+		Janus.vdebug = Janus.noop;
+		Janus.log = Janus.noop;
+		Janus.warn = Janus.noop;
+		Janus.error = Janus.noop;
+		if(options.debug === true || options.debug === "all") {
+			// Enable all debugging levels
+			Janus.trace = console.trace.bind(console);
+			Janus.debug = console.debug.bind(console);
+			Janus.vdebug = console.debug.bind(console);
+			Janus.log = console.log.bind(console);
+			Janus.warn = console.warn.bind(console);
+			Janus.error = console.error.bind(console);
+		} else if(Array.isArray(options.debug)) {
+			for(var i in options.debug) {
+				var d = options.debug[i];
+				switch(d) {
+					case "trace":
+						Janus.trace = console.trace.bind(console);
+						break;
+					case "debug":
+						Janus.debug = console.debug.bind(console);
+						break;
+					case "vdebug":
+						Janus.vdebug = console.debug.bind(console);
+						break;
+					case "log":
+						Janus.log = console.log.bind(console);
+						break;
+					case "warn":
+						Janus.warn = console.warn.bind(console);
+						break;
+					case "error":
+						Janus.error = console.error.bind(console);
+						break;
+					default:
+						console.error("Unknown debugging option '" + d + "' (supported: 'trace', 'debug', 'vdebug', 'log', warn', 'error')");
+						break;
+				}
+			}
+		}
+		Janus.log("Initializing library");
+
+		var usedDependencies = options.dependencies || Janus.useDefaultDependencies();
+		Janus.isArray = usedDependencies.isArray;
+		Janus.webRTCAdapter = usedDependencies.webRTCAdapter;
+		Janus.httpAPICall = usedDependencies.httpAPICall;
+		Janus.checkJanusExtension = usedDependencies.checkJanusExtension;
+		Janus.newWebSocket = usedDependencies.newWebSocket;
+
+		// Helper method to enumerate devices
+		Janus.listDevices = function(callback, config) {
+			callback = (typeof callback == "function") ? callback : Janus.noop;
+			if (config == null) config = { audio: true, video: true };
+			if(navigator.mediaDevices) {
+				navigator.mediaDevices.getUserMedia(config)
+				.then(function(stream) {
+					navigator.mediaDevices.enumerateDevices().then(function(devices) {
+						Janus.debug(devices);
+						callback(devices);
+						// Get rid of the now useless stream
+						try {
+							var tracks = stream.getTracks();
+							for(var i in tracks) {
+								var mst = tracks[i];
+								if(mst !== null && mst !== undefined)
+									mst.stop();
+							}
+						} catch(e) {}
+					});
+				})
+				.catch(function(err) {
+					Janus.error(err);
+					callback([]);
+				});
+			} else {
+				Janus.warn("navigator.mediaDevices unavailable");
+				callback([]);
+			}
+		}
+		// Helper methods to attach/reattach a stream to a video element (previously part of adapter.js)
+		Janus.attachMediaStream = function(element, stream) {
+			if(Janus.webRTCAdapter.browserDetails.browser === 'chrome') {
+				var chromever = Janus.webRTCAdapter.browserDetails.version;
+				if(chromever >= 43) {
+					element.srcObject = stream;
+				} else if(typeof element.src !== 'undefined') {
+					element.src = URL.createObjectURL(stream);
+				} else {
+					Janus.error("Error attaching stream to element");
+				}
+			} else {
+				element.srcObject = stream;
+			}
+		};
+		Janus.reattachMediaStream = function(to, from) {
+			if(Janus.webRTCAdapter.browserDetails.browser === 'chrome') {
+				var chromever = Janus.webRTCAdapter.browserDetails.version;
+				if(chromever >= 43) {
+					to.srcObject = from.srcObject;
+				} else if(typeof to.src !== 'undefined') {
+					to.src = from.src;
+				} else {
+					Janus.error("Error reattaching stream to element");
+				}
+			} else {
+				to.srcObject = from.srcObject;
+			}
+		};
+		// Detect tab close: make sure we don't loose existing onbeforeunload handlers
+		var oldOBF = window.onbeforeunload;
+		window.onbeforeunload = function() {
+			Janus.log("Closing window");
+			for(var s in Janus.sessions) {
+				if(Janus.sessions[s] !== null && Janus.sessions[s] !== undefined &&
+						Janus.sessions[s].destroyOnUnload) {
+					Janus.log("Destroying session " + s);
+					Janus.sessions[s].destroy({asyncRequest: false, notifyDestroyed: false});
+				}
+			}
+			if(oldOBF && typeof oldOBF == "function")
+				oldOBF();
+		}
+		Janus.initDone = true;
+		options.callback();
+	}
+};
+
+// Helper method to check whether WebRTC is supported by this browser
+Janus.isWebrtcSupported = function() {
+	return window.RTCPeerConnection !== undefined && window.RTCPeerConnection !== null &&
+		navigator.getUserMedia !== undefined && navigator.getUserMedia !== null;
+};
+
+// Helper method to create random identifiers (e.g., transaction)
+Janus.randomString = function(len) {
+	var charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	var randomString = '';
+	for (var i = 0; i < len; i++) {
+		var randomPoz = Math.floor(Math.random() * charSet.length);
+		randomString += charSet.substring(randomPoz,randomPoz+1);
+	}
+	return randomString;
+}
+
+
+function Janus(gatewayCallbacks) {
+	if(Janus.initDone === undefined) {
+		gatewayCallbacks.error("Library not initialized");
+		return {};
+	}
+	if(!Janus.isWebrtcSupported()) {
+		gatewayCallbacks.error("WebRTC not supported by this browser");
+		return {};
+	}
+	Janus.log("Library initialized: " + Janus.initDone);
+	gatewayCallbacks = gatewayCallbacks || {};
+	gatewayCallbacks.success = (typeof gatewayCallbacks.success == "function") ? gatewayCallbacks.success : Janus.noop;
+	gatewayCallbacks.error = (typeof gatewayCallbacks.error == "function") ? gatewayCallbacks.error : Janus.noop;
+	gatewayCallbacks.destroyed = (typeof gatewayCallbacks.destroyed == "function") ? gatewayCallbacks.destroyed : Janus.noop;
+	if(gatewayCallbacks.server === null || gatewayCallbacks.server === undefined) {
+		gatewayCallbacks.error("Invalid gateway url");
+		return {};
+	}
+	var websockets = false;
+	var ws = null;
+	var wsHandlers = {};
+	var wsKeepaliveTimeoutId = null;
+
+	var servers = null, serversIndex = 0;
+	var server = gatewayCallbacks.server;
+	if(Janus.isArray(server)) {
+		Janus.log("Multiple servers provided (" + server.length + "), will use the first that works");
+		server = null;
+		servers = gatewayCallbacks.server;
+		Janus.debug(servers);
+	} else {
+		if(server.indexOf("ws") === 0) {
+			websockets = true;
+			Janus.log("Using WebSockets to contact Janus: " + server);
+		} else {
+			websockets = false;
+			Janus.log("Using REST API to contact Janus: " + server);
+		}
+	}
+	var iceServers = gatewayCallbacks.iceServers;
+	if(iceServers === undefined || iceServers === null)
+		iceServers = [{urls: "stun:stun.l.google.com:19302"}];
+	var iceTransportPolicy = gatewayCallbacks.iceTransportPolicy;
+	var bundlePolicy = gatewayCallbacks.bundlePolicy;
+	// Whether IPv6 candidates should be gathered
+	var ipv6Support = gatewayCallbacks.ipv6;
+	if(ipv6Support === undefined || ipv6Support === null)
+		ipv6Support = false;
+	// Whether we should enable the withCredentials flag for XHR requests
+	var withCredentials = false;
+	if(gatewayCallbacks.withCredentials !== undefined && gatewayCallbacks.withCredentials !== null)
+		withCredentials = gatewayCallbacks.withCredentials === true;
+	// Optional max events
+	var maxev = null;
+	if(gatewayCallbacks.max_poll_events !== undefined && gatewayCallbacks.max_poll_events !== null)
+		maxev = gatewayCallbacks.max_poll_events;
+	if(maxev < 1)
+		maxev = 1;
+	// Token to use (only if the token based authentication mechanism is enabled)
+	var token = null;
+	if(gatewayCallbacks.token !== undefined && gatewayCallbacks.token !== null)
+		token = gatewayCallbacks.token;
+	// API secret to use (only if the shared API secret is enabled)
+	var apisecret = null;
+	if(gatewayCallbacks.apisecret !== undefined && gatewayCallbacks.apisecret !== null)
+		apisecret = gatewayCallbacks.apisecret;
+	// Whether we should destroy this session when onbeforeunload is called
+	this.destroyOnUnload = true;
+	if(gatewayCallbacks.destroyOnUnload !== undefined && gatewayCallbacks.destroyOnUnload !== null)
+		this.destroyOnUnload = (gatewayCallbacks.destroyOnUnload === true);
+
+	var connected = false;
+	var sessionId = null;
+	var pluginHandles = {};
+	var that = this;
+	var retries = 0;
+	var transactions = {};
+	createSession(gatewayCallbacks);
+
+	// Public methods
+	this.getServer = function() { return server; };
+	this.isConnected = function() { return connected; };
+	this.reconnect = function(callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		callbacks["reconnect"] = true;
+		createSession(callbacks);
+	};
+	this.getSessionId = function() { return sessionId; };
+	this.destroy = function(callbacks) { destroySession(callbacks); };
+	this.attach = function(callbacks) { createHandle(callbacks); };
+
+	function eventHandler() {
+		if(sessionId == null)
+			return;
+		Janus.debug('Long poll...');
+		if(!connected) {
+			Janus.warn("Is the gateway down? (connected=false)");
+			return;
+		}
+		var longpoll = server + "/" + sessionId + "?rid=" + new Date().getTime();
+		if(maxev !== undefined && maxev !== null)
+			longpoll = longpoll + "&maxev=" + maxev;
+		if(token !== null && token !== undefined)
+			longpoll = longpoll + "&token=" + token;
+		if(apisecret !== null && apisecret !== undefined)
+			longpoll = longpoll + "&apisecret=" + apisecret;
+		Janus.httpAPICall(longpoll, {
+			verb: 'GET',
+			withCredentials: withCredentials,
+			success: handleEvent,
+			timeout: 60000,	// FIXME
+			error: function(textStatus, errorThrown) {
+				Janus.error(textStatus + ":", errorThrown);
+				retries++;
+				if(retries > 3) {
+					// Did we just lose the gateway? :-(
+					connected = false;
+					gatewayCallbacks.error("Lost connection to the gateway (is it down?)");
+					return;
+				}
+				eventHandler();
+			}
+		});
+	}
+
+	// Private event handler: this will trigger plugin callbacks, if set
+	function handleEvent(json, skipTimeout) {
+		retries = 0;
+		if(!websockets && sessionId !== undefined && sessionId !== null && skipTimeout !== true)
+			setTimeout(eventHandler, 200);
+		if(!websockets && Janus.isArray(json)) {
+			// We got an array: it means we passed a maxev > 1, iterate on all objects
+			for(var i=0; i<json.length; i++) {
+				handleEvent(json[i], true);
+			}
+			return;
+		}
+		if(json["janus"] === "keepalive") {
+			// Nothing happened
+			Janus.vdebug("Got a keepalive on session " + sessionId);
+			return;
+		} else if(json["janus"] === "ack") {
+			// Just an ack, we can probably ignore
+			Janus.debug("Got an ack on session " + sessionId);
+			Janus.debug(json);
+			var transaction = json["transaction"];
+			if(transaction !== null && transaction !== undefined) {
+				var reportSuccess = transactions[transaction];
+				if(reportSuccess !== null && reportSuccess !== undefined) {
+					reportSuccess(json);
+				}
+				delete transactions[transaction];
+			}
+			return;
+		} else if(json["janus"] === "success") {
+			// Success!
+			Janus.debug("Got a success on session " + sessionId);
+			Janus.debug(json);
+			var transaction = json["transaction"];
+			if(transaction !== null && transaction !== undefined) {
+				var reportSuccess = transactions[transaction];
+				if(reportSuccess !== null && reportSuccess !== undefined) {
+					reportSuccess(json);
+				}
+				delete transactions[transaction];
+			}
+			return;
+		} else if(json["janus"] === "trickle") {
+			// We got a trickle candidate from Janus
+			var sender = json["sender"];
+			if(sender === undefined || sender === null) {
+				Janus.warn("Missing sender...");
+				return;
+			}
+			var pluginHandle = pluginHandles[sender];
+			if(pluginHandle === undefined || pluginHandle === null) {
+				Janus.debug("This handle is not attached to this session");
+				return;
+			}
+			var candidate = json["candidate"];
+			Janus.debug("Got a trickled candidate on session " + sessionId);
+			Janus.debug(candidate);
+			var config = pluginHandle.webrtcStuff;
+			if(config.pc && config.remoteSdp) {
+				// Add candidate right now
+				Janus.debug("Adding remote candidate:", candidate);
+				if(!candidate || candidate.completed === true) {
+					// end-of-candidates
+					config.pc.addIceCandidate();
+				} else {
+					// New candidate
+					config.pc.addIceCandidate(new RTCIceCandidate(candidate));
+				}
+			} else {
+				// We didn't do setRemoteDescription (trickle got here before the offer?)
+				Janus.debug("We didn't do setRemoteDescription (trickle got here before the offer?), caching candidate");
+				if(!config.candidates)
+					config.candidates = [];
+				config.candidates.push(candidate);
+				Janus.debug(config.candidates);
+			}
+		} else if(json["janus"] === "webrtcup") {
+			// The PeerConnection with the gateway is up! Notify this
+			Janus.debug("Got a webrtcup event on session " + sessionId);
+			Janus.debug(json);
+			var sender = json["sender"];
+			if(sender === undefined || sender === null) {
+				Janus.warn("Missing sender...");
+				return;
+			}
+			var pluginHandle = pluginHandles[sender];
+			if(pluginHandle === undefined || pluginHandle === null) {
+				Janus.debug("This handle is not attached to this session");
+				return;
+			}
+			pluginHandle.webrtcState(true);
+			return;
+		} else if(json["janus"] === "hangup") {
+			// A plugin asked the core to hangup a PeerConnection on one of our handles
+			Janus.debug("Got a hangup event on session " + sessionId);
+			Janus.debug(json);
+			var sender = json["sender"];
+			if(sender === undefined || sender === null) {
+				Janus.warn("Missing sender...");
+				return;
+			}
+			var pluginHandle = pluginHandles[sender];
+			if(pluginHandle === undefined || pluginHandle === null) {
+				Janus.debug("This handle is not attached to this session");
+				return;
+			}
+			pluginHandle.webrtcState(false, json["reason"]);
+			pluginHandle.hangup();
+		} else if(json["janus"] === "detached") {
+			// A plugin asked the core to detach one of our handles
+			Janus.debug("Got a detached event on session " + sessionId);
+			Janus.debug(json);
+			var sender = json["sender"];
+			if(sender === undefined || sender === null) {
+				Janus.warn("Missing sender...");
+				return;
+			}
+			var pluginHandle = pluginHandles[sender];
+			if(pluginHandle === undefined || pluginHandle === null) {
+				// Don't warn here because destroyHandle causes this situation.
+				return;
+			}
+			pluginHandle.detached = true;
+			pluginHandle.ondetached();
+			pluginHandle.detach();
+		} else if(json["janus"] === "media") {
+			// Media started/stopped flowing
+			Janus.debug("Got a media event on session " + sessionId);
+			Janus.debug(json);
+			var sender = json["sender"];
+			if(sender === undefined || sender === null) {
+				Janus.warn("Missing sender...");
+				return;
+			}
+			var pluginHandle = pluginHandles[sender];
+			if(pluginHandle === undefined || pluginHandle === null) {
+				Janus.debug("This handle is not attached to this session");
+				return;
+			}
+			pluginHandle.mediaState(json["type"], json["receiving"]);
+		} else if(json["janus"] === "slowlink") {
+			Janus.debug("Got a slowlink event on session " + sessionId);
+			Janus.debug(json);
+			// Trouble uplink or downlink
+			var sender = json["sender"];
+			if(sender === undefined || sender === null) {
+				Janus.warn("Missing sender...");
+				return;
+			}
+			var pluginHandle = pluginHandles[sender];
+			if(pluginHandle === undefined || pluginHandle === null) {
+				Janus.debug("This handle is not attached to this session");
+				return;
+			}
+			pluginHandle.slowLink(json["uplink"], json["nacks"]);
+		} else if(json["janus"] === "error") {
+			// Oops, something wrong happened
+			Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+			Janus.debug(json);
+			var transaction = json["transaction"];
+			if(transaction !== null && transaction !== undefined) {
+				var reportSuccess = transactions[transaction];
+				if(reportSuccess !== null && reportSuccess !== undefined) {
+					reportSuccess(json);
+				}
+				delete transactions[transaction];
+			}
+			return;
+		} else if(json["janus"] === "event") {
+			Janus.debug("Got a plugin event on session " + sessionId);
+			Janus.debug(json);
+			var sender = json["sender"];
+			if(sender === undefined || sender === null) {
+				Janus.warn("Missing sender...");
+				return;
+			}
+			var plugindata = json["plugindata"];
+			if(plugindata === undefined || plugindata === null) {
+				Janus.warn("Missing plugindata...");
+				return;
+			}
+			Janus.debug("  -- Event is coming from " + sender + " (" + plugindata["plugin"] + ")");
+			var data = plugindata["data"];
+			Janus.debug(data);
+			var pluginHandle = pluginHandles[sender];
+			if(pluginHandle === undefined || pluginHandle === null) {
+				Janus.warn("This handle is not attached to this session");
+				return;
+			}
+			var jsep = json["jsep"];
+			if(jsep !== undefined && jsep !== null) {
+				Janus.debug("Handling SDP as well...");
+				Janus.debug(jsep);
+			}
+			var callback = pluginHandle.onmessage;
+			if(callback !== null && callback !== undefined) {
+				Janus.debug("Notifying application...");
+				// Send to callback specified when attaching plugin handle
+				callback(data, jsep);
+			} else {
+				// Send to generic callback (?)
+				Janus.debug("No provided notification callback");
+			}
+		} else {
+			Janus.warn("Unknown message/event  '" + json["janus"] + "' on session " + sessionId);
+			Janus.debug(json);
+		}
+	}
+
+	// Private helper to send keep-alive messages on WebSockets
+	function keepAlive() {
+		if(server === null || !websockets || !connected)
+			return;
+		wsKeepaliveTimeoutId = setTimeout(keepAlive, 30000);
+		var request = { "janus": "keepalive", "session_id": sessionId, "transaction": Janus.randomString(12) };
+		if(token !== null && token !== undefined)
+			request["token"] = token;
+		if(apisecret !== null && apisecret !== undefined)
+			request["apisecret"] = apisecret;
+		ws.send(JSON.stringify(request));
+	}
+
+	// Private method to create a session
+	function createSession(callbacks) {
+		var transaction = Janus.randomString(12);
+		var request = { "janus": "create", "transaction": transaction };
+		if(callbacks["reconnect"]) {
+			// We're reconnecting, claim the session
+			connected = false;
+			request["janus"] = "claim";
+			request["session_id"] = sessionId;
+			// If we were using websockets, ignore the old connection
+			if(ws) {
+				ws.onopen = null;
+				ws.onerror = null;
+				ws.onclose = null;
+				if(wsKeepaliveTimeoutId) {
+					clearTimeout(wsKeepaliveTimeoutId);
+					wsKeepaliveTimeoutId = null;
+				}
+			}
+		}
+		if(token !== null && token !== undefined)
+			request["token"] = token;
+		if(apisecret !== null && apisecret !== undefined)
+			request["apisecret"] = apisecret;
+		if(server === null && Janus.isArray(servers)) {
+			// We still need to find a working server from the list we were given
+			server = servers[serversIndex];
+			if(server.indexOf("ws") === 0) {
+				websockets = true;
+				Janus.log("Server #" + (serversIndex+1) + ": trying WebSockets to contact Janus (" + server + ")");
+			} else {
+				websockets = false;
+				Janus.log("Server #" + (serversIndex+1) + ": trying REST API to contact Janus (" + server + ")");
+			}
+		}
+		if(websockets) {
+			ws = Janus.newWebSocket(server, 'janus-protocol');
+			wsHandlers = {
+				'error': function() {
+					Janus.error("Error connecting to the Janus WebSockets server... " + server);
+					if (Janus.isArray(servers)) {
+						serversIndex++;
+						if (serversIndex == servers.length) {
+							// We tried all the servers the user gave us and they all failed
+							callbacks.error("Error connecting to any of the provided Janus servers: Is the gateway down?");
+							return;
+						}
+						// Let's try the next server
+						server = null;
+						setTimeout(function() {
+							createSession(callbacks);
+						}, 200);
+						return;
+					}
+					callbacks.error("Error connecting to the Janus WebSockets server: Is the gateway down?");
+				},
+
+				'open': function() {
+					// We need to be notified about the success
+					transactions[transaction] = function(json) {
+						Janus.debug(json);
+						if (json["janus"] !== "success") {
+							Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+							callbacks.error(json["error"].reason);
+							return;
+						}
+						wsKeepaliveTimeoutId = setTimeout(keepAlive, 30000);
+						connected = true;
+						sessionId = json["session_id"] ? json["session_id"] : json.data["id"];
+						if(callbacks["reconnect"]) {
+							Janus.log("Claimed session: " + sessionId);
+						} else {
+							Janus.log("Created session: " + sessionId);
+						}
+						Janus.sessions[sessionId] = that;
+						callbacks.success();
+					};
+					ws.send(JSON.stringify(request));
+				},
+
+				'message': function(event) {
+					handleEvent(JSON.parse(event.data));
+				},
+
+				'close': function() {
+					if (server === null || !connected) {
+						return;
+					}
+					connected = false;
+					// FIXME What if this is called when the page is closed?
+					gatewayCallbacks.error("Lost connection to the gateway (is it down?)");
+				}
+			};
+
+			for(var eventName in wsHandlers) {
+				ws.addEventListener(eventName, wsHandlers[eventName]);
+			}
+
+			return;
+		}
+		Janus.httpAPICall(server, {
+			verb: 'POST',
+			withCredentials: withCredentials,
+			body: request,
+			success: function(json) {
+				Janus.debug(json);
+				if(json["janus"] !== "success") {
+					Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+					callbacks.error(json["error"].reason);
+					return;
+				}
+				connected = true;
+				sessionId = json["session_id"] ? json["session_id"] : json.data["id"];
+				if(callbacks["reconnect"]) {
+					Janus.log("Claimed session: " + sessionId);
+				} else {
+					Janus.log("Created session: " + sessionId);
+				}
+				Janus.sessions[sessionId] = that;
+				eventHandler();
+				callbacks.success();
+			},
+			error: function(textStatus, errorThrown) {
+				Janus.error(textStatus + ":", errorThrown);	// FIXME
+				if(Janus.isArray(servers)) {
+					serversIndex++;
+					if(serversIndex == servers.length) {
+						// We tried all the servers the user gave us and they all failed
+						callbacks.error("Error connecting to any of the provided Janus servers: Is the gateway down?");
+						return;
+					}
+					// Let's try the next server
+					server = null;
+					setTimeout(function() { createSession(callbacks); }, 200);
+					return;
+				}
+				if(errorThrown === "")
+					callbacks.error(textStatus + ": Is the gateway down?");
+				else
+					callbacks.error(textStatus + ": " + errorThrown);
+			}
+		});
+	}
+
+	// Private method to destroy a session
+	function destroySession(callbacks) {
+		callbacks = callbacks || {};
+		// FIXME This method triggers a success even when we fail
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		var asyncRequest = true;
+		if(callbacks.asyncRequest !== undefined && callbacks.asyncRequest !== null)
+			asyncRequest = (callbacks.asyncRequest === true);
+		var notifyDestroyed = true;
+		if(callbacks.notifyDestroyed !== undefined && callbacks.notifyDestroyed !== null)
+			notifyDestroyed = (callbacks.notifyDestroyed === true);
+		Janus.log("Destroying session " + sessionId + " (async=" + asyncRequest + ")");
+		if(!connected) {
+			Janus.warn("Is the gateway down? (connected=false)");
+			callbacks.success();
+			return;
+		}
+		if(sessionId === undefined || sessionId === null) {
+			Janus.warn("No session to destroy");
+			callbacks.success();
+			if(notifyDestroyed)
+				gatewayCallbacks.destroyed();
+			return;
+		}
+		delete Janus.sessions[sessionId];
+		// No need to destroy all handles first, Janus will do that itself
+		var request = { "janus": "destroy", "transaction": Janus.randomString(12) };
+		if(token !== null && token !== undefined)
+			request["token"] = token;
+		if(apisecret !== null && apisecret !== undefined)
+			request["apisecret"] = apisecret;
+		if(websockets) {
+			request["session_id"] = sessionId;
+
+			var unbindWebSocket = function() {
+				for(var eventName in wsHandlers) {
+					ws.removeEventListener(eventName, wsHandlers[eventName]);
+				}
+				ws.removeEventListener('message', onUnbindMessage);
+				ws.removeEventListener('error', onUnbindError);
+				if(wsKeepaliveTimeoutId) {
+					clearTimeout(wsKeepaliveTimeoutId);
+				}
+				ws.close();
+			};
+
+			var onUnbindMessage = function(event){
+				var data = JSON.parse(event.data);
+				if(data.session_id == request.session_id && data.transaction == request.transaction) {
+					unbindWebSocket();
+					callbacks.success();
+					if(notifyDestroyed)
+						gatewayCallbacks.destroyed();
+				}
+			};
+			var onUnbindError = function(event) {
+				unbindWebSocket();
+				callbacks.error("Failed to destroy the gateway: Is the gateway down?");
+				if(notifyDestroyed)
+					gatewayCallbacks.destroyed();
+			};
+
+			ws.addEventListener('message', onUnbindMessage);
+			ws.addEventListener('error', onUnbindError);
+
+			ws.send(JSON.stringify(request));
+			return;
+		}
+		Janus.httpAPICall(server + "/" + sessionId, {
+			verb: 'POST',
+			async: asyncRequest,	// Sometimes we need false here, or destroying in onbeforeunload won't work
+			withCredentials: withCredentials,
+			body: request,
+			success: function(json) {
+				Janus.log("Destroyed session:");
+				Janus.debug(json);
+				sessionId = null;
+				connected = false;
+				if(json["janus"] !== "success") {
+					Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+				}
+				callbacks.success();
+				if(notifyDestroyed)
+					gatewayCallbacks.destroyed();
+			},
+			error: function(textStatus, errorThrown) {
+				Janus.error(textStatus + ":", errorThrown);	// FIXME
+				// Reset everything anyway
+				sessionId = null;
+				connected = false;
+				callbacks.success();
+				if(notifyDestroyed)
+					gatewayCallbacks.destroyed();
+			}
+		});
+	}
+
+	// Private method to create a plugin handle
+	function createHandle(callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		callbacks.consentDialog = (typeof callbacks.consentDialog == "function") ? callbacks.consentDialog : Janus.noop;
+		callbacks.iceState = (typeof callbacks.iceState == "function") ? callbacks.iceState : Janus.noop;
+		callbacks.mediaState = (typeof callbacks.mediaState == "function") ? callbacks.mediaState : Janus.noop;
+		callbacks.webrtcState = (typeof callbacks.webrtcState == "function") ? callbacks.webrtcState : Janus.noop;
+		callbacks.slowLink = (typeof callbacks.slowLink == "function") ? callbacks.slowLink : Janus.noop;
+		callbacks.onmessage = (typeof callbacks.onmessage == "function") ? callbacks.onmessage : Janus.noop;
+		callbacks.onlocalstream = (typeof callbacks.onlocalstream == "function") ? callbacks.onlocalstream : Janus.noop;
+		callbacks.onremotestream = (typeof callbacks.onremotestream == "function") ? callbacks.onremotestream : Janus.noop;
+		callbacks.ondata = (typeof callbacks.ondata == "function") ? callbacks.ondata : Janus.noop;
+		callbacks.ondataopen = (typeof callbacks.ondataopen == "function") ? callbacks.ondataopen : Janus.noop;
+		callbacks.oncleanup = (typeof callbacks.oncleanup == "function") ? callbacks.oncleanup : Janus.noop;
+		callbacks.ondetached = (typeof callbacks.ondetached == "function") ? callbacks.ondetached : Janus.noop;
+		if(!connected) {
+			Janus.warn("Is the gateway down? (connected=false)");
+			callbacks.error("Is the gateway down? (connected=false)");
+			return;
+		}
+		var plugin = callbacks.plugin;
+		if(plugin === undefined || plugin === null) {
+			Janus.error("Invalid plugin");
+			callbacks.error("Invalid plugin");
+			return;
+		}
+		var opaqueId = callbacks.opaqueId;
+		var handleToken = callbacks.token ? callbacks.token : token;
+		var transaction = Janus.randomString(12);
+		var request = { "janus": "attach", "plugin": plugin, "opaque_id": opaqueId, "transaction": transaction };
+		if(handleToken !== null && handleToken !== undefined)
+			request["token"] = handleToken;
+		if(apisecret !== null && apisecret !== undefined)
+			request["apisecret"] = apisecret;
+		if(websockets) {
+			transactions[transaction] = function(json) {
+				Janus.debug(json);
+				if(json["janus"] !== "success") {
+					Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+					callbacks.error("Ooops: " + json["error"].code + " " + json["error"].reason);
+					return;
+				}
+				var handleId = json.data["id"];
+				Janus.log("Created handle: " + handleId);
+				var pluginHandle =
+					{
+						session : that,
+						plugin : plugin,
+						id : handleId,
+						token : handleToken,
+						detached : false,
+						webrtcStuff : {
+							started : false,
+							myStream : null,
+							streamExternal : false,
+							remoteStream : null,
+							mySdp : null,
+							mediaConstraints : null,
+							pc : null,
+							dataChannel : null,
+							dtmfSender : null,
+							trickle : true,
+							iceDone : false,
+							volume : {
+								value : null,
+								timer : null
+							},
+							bitrate : {
+								value : null,
+								bsnow : null,
+								bsbefore : null,
+								tsnow : null,
+								tsbefore : null,
+								timer : null
+							}
+						},
+						getId : function() { return handleId; },
+						getPlugin : function() { return plugin; },
+						getVolume : function() { return getVolume(handleId); },
+						isAudioMuted : function() { return isMuted(handleId, false); },
+						muteAudio : function() { return mute(handleId, false, true); },
+						unmuteAudio : function() { return mute(handleId, false, false); },
+						isVideoMuted : function() { return isMuted(handleId, true); },
+						muteVideo : function() { return mute(handleId, true, true); },
+						unmuteVideo : function() { return mute(handleId, true, false); },
+						getBitrate : function() { return getBitrate(handleId); },
+						send : function(callbacks) { sendMessage(handleId, callbacks); },
+						data : function(callbacks) { sendData(handleId, callbacks); },
+						dtmf : function(callbacks) { sendDtmf(handleId, callbacks); },
+						consentDialog : callbacks.consentDialog,
+						iceState : callbacks.iceState,
+						mediaState : callbacks.mediaState,
+						webrtcState : callbacks.webrtcState,
+						slowLink : callbacks.slowLink,
+						onmessage : callbacks.onmessage,
+						createOffer : function(callbacks) { prepareWebrtc(handleId, callbacks); },
+						createAnswer : function(callbacks) { prepareWebrtc(handleId, callbacks); },
+						handleRemoteJsep : function(callbacks) { prepareWebrtcPeer(handleId, callbacks); },
+						onlocalstream : callbacks.onlocalstream,
+						onremotestream : callbacks.onremotestream,
+						ondata : callbacks.ondata,
+						ondataopen : callbacks.ondataopen,
+						oncleanup : callbacks.oncleanup,
+						ondetached : callbacks.ondetached,
+						hangup : function(sendRequest) { cleanupWebrtc(handleId, sendRequest === true); },
+						detach : function(callbacks) { destroyHandle(handleId, callbacks); }
+					}
+				pluginHandles[handleId] = pluginHandle;
+				callbacks.success(pluginHandle);
+			};
+			request["session_id"] = sessionId;
+			ws.send(JSON.stringify(request));
+			return;
+		}
+		Janus.httpAPICall(server + "/" + sessionId, {
+			verb: 'POST',
+			withCredentials: withCredentials,
+			body: request,
+			success: function(json) {
+				Janus.debug(json);
+				if(json["janus"] !== "success") {
+					Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+					callbacks.error("Ooops: " + json["error"].code + " " + json["error"].reason);
+					return;
+				}
+				var handleId = json.data["id"];
+				Janus.log("Created handle: " + handleId);
+				var pluginHandle =
+					{
+						session : that,
+						plugin : plugin,
+						id : handleId,
+						token : handleToken,
+						detached : false,
+						webrtcStuff : {
+							started : false,
+							myStream : null,
+							streamExternal : false,
+							remoteStream : null,
+							mySdp : null,
+							mediaConstraints : null,
+							pc : null,
+							dataChannel : null,
+							dtmfSender : null,
+							trickle : true,
+							iceDone : false,
+							volume : {
+								value : null,
+								timer : null
+							},
+							bitrate : {
+								value : null,
+								bsnow : null,
+								bsbefore : null,
+								tsnow : null,
+								tsbefore : null,
+								timer : null
+							}
+						},
+						getId : function() { return handleId; },
+						getPlugin : function() { return plugin; },
+						getVolume : function() { return getVolume(handleId); },
+						isAudioMuted : function() { return isMuted(handleId, false); },
+						muteAudio : function() { return mute(handleId, false, true); },
+						unmuteAudio : function() { return mute(handleId, false, false); },
+						isVideoMuted : function() { return isMuted(handleId, true); },
+						muteVideo : function() { return mute(handleId, true, true); },
+						unmuteVideo : function() { return mute(handleId, true, false); },
+						getBitrate : function() { return getBitrate(handleId); },
+						send : function(callbacks) { sendMessage(handleId, callbacks); },
+						data : function(callbacks) { sendData(handleId, callbacks); },
+						dtmf : function(callbacks) { sendDtmf(handleId, callbacks); },
+						consentDialog : callbacks.consentDialog,
+						iceState : callbacks.iceState,
+						mediaState : callbacks.mediaState,
+						webrtcState : callbacks.webrtcState,
+						slowLink : callbacks.slowLink,
+						onmessage : callbacks.onmessage,
+						createOffer : function(callbacks) { prepareWebrtc(handleId, callbacks); },
+						createAnswer : function(callbacks) { prepareWebrtc(handleId, callbacks); },
+						handleRemoteJsep : function(callbacks) { prepareWebrtcPeer(handleId, callbacks); },
+						onlocalstream : callbacks.onlocalstream,
+						onremotestream : callbacks.onremotestream,
+						ondata : callbacks.ondata,
+						ondataopen : callbacks.ondataopen,
+						oncleanup : callbacks.oncleanup,
+						ondetached : callbacks.ondetached,
+						hangup : function(sendRequest) { cleanupWebrtc(handleId, sendRequest === true); },
+						detach : function(callbacks) { destroyHandle(handleId, callbacks); }
+					}
+				pluginHandles[handleId] = pluginHandle;
+				callbacks.success(pluginHandle);
+			},
+			error: function(textStatus, errorThrown) {
+				Janus.error(textStatus + ":", errorThrown);	// FIXME
+			}
+		});
+	}
+
+	// Private method to send a message
+	function sendMessage(handleId, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		if(!connected) {
+			Janus.warn("Is the gateway down? (connected=false)");
+			callbacks.error("Is the gateway down? (connected=false)");
+			return;
+		}
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var message = callbacks.message;
+		var jsep = callbacks.jsep;
+		var transaction = Janus.randomString(12);
+		var request = { "janus": "message", "body": message, "transaction": transaction };
+		if(pluginHandle.token !== null && pluginHandle.token !== undefined)
+			request["token"] = pluginHandle.token;
+		if(apisecret !== null && apisecret !== undefined)
+			request["apisecret"] = apisecret;
+		if(jsep !== null && jsep !== undefined)
+			request.jsep = jsep;
+		Janus.debug("Sending message to plugin (handle=" + handleId + "):");
+		Janus.debug(request);
+		if(websockets) {
+			request["session_id"] = sessionId;
+			request["handle_id"] = handleId;
+			transactions[transaction] = function(json) {
+				Janus.debug("Message sent!");
+				Janus.debug(json);
+				if(json["janus"] === "success") {
+					// We got a success, must have been a synchronous transaction
+					var plugindata = json["plugindata"];
+					if(plugindata === undefined || plugindata === null) {
+						Janus.warn("Request succeeded, but missing plugindata...");
+						callbacks.success();
+						return;
+					}
+					Janus.log("Synchronous transaction successful (" + plugindata["plugin"] + ")");
+					var data = plugindata["data"];
+					Janus.debug(data);
+					callbacks.success(data);
+					return;
+				} else if(json["janus"] !== "ack") {
+					// Not a success and not an ack, must be an error
+					if(json["error"] !== undefined && json["error"] !== null) {
+						Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+						callbacks.error(json["error"].code + " " + json["error"].reason);
+					} else {
+						Janus.error("Unknown error");	// FIXME
+						callbacks.error("Unknown error");
+					}
+					return;
+				}
+				// If we got here, the plugin decided to handle the request asynchronously
+				callbacks.success();
+			};
+			ws.send(JSON.stringify(request));
+			return;
+		}
+		Janus.httpAPICall(server + "/" + sessionId + "/" + handleId, {
+			verb: 'POST',
+			withCredentials: withCredentials,
+			body: request,
+			success: function(json) {
+				Janus.debug("Message sent!");
+				Janus.debug(json);
+				if(json["janus"] === "success") {
+					// We got a success, must have been a synchronous transaction
+					var plugindata = json["plugindata"];
+					if(plugindata === undefined || plugindata === null) {
+						Janus.warn("Request succeeded, but missing plugindata...");
+						callbacks.success();
+						return;
+					}
+					Janus.log("Synchronous transaction successful (" + plugindata["plugin"] + ")");
+					var data = plugindata["data"];
+					Janus.debug(data);
+					callbacks.success(data);
+					return;
+				} else if(json["janus"] !== "ack") {
+					// Not a success and not an ack, must be an error
+					if(json["error"] !== undefined && json["error"] !== null) {
+						Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+						callbacks.error(json["error"].code + " " + json["error"].reason);
+					} else {
+						Janus.error("Unknown error");	// FIXME
+						callbacks.error("Unknown error");
+					}
+					return;
+				}
+				// If we got here, the plugin decided to handle the request asynchronously
+				callbacks.success();
+			},
+			error: function(textStatus, errorThrown) {
+				Janus.error(textStatus + ":", errorThrown);	// FIXME
+				callbacks.error(textStatus + ": " + errorThrown);
+			}
+		});
+	}
+
+	// Private method to send a trickle candidate
+	function sendTrickleCandidate(handleId, candidate) {
+		if(!connected) {
+			Janus.warn("Is the gateway down? (connected=false)");
+			return;
+		}
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var request = { "janus": "trickle", "candidate": candidate, "transaction": Janus.randomString(12) };
+		if(pluginHandle.token !== null && pluginHandle.token !== undefined)
+			request["token"] = pluginHandle.token;
+		if(apisecret !== null && apisecret !== undefined)
+			request["apisecret"] = apisecret;
+		Janus.vdebug("Sending trickle candidate (handle=" + handleId + "):");
+		Janus.vdebug(request);
+		if(websockets) {
+			request["session_id"] = sessionId;
+			request["handle_id"] = handleId;
+			ws.send(JSON.stringify(request));
+			return;
+		}
+		Janus.httpAPICall(server + "/" + sessionId + "/" + handleId, {
+			verb: 'POST',
+			withCredentials: withCredentials,
+			body: request,
+			success: function(json) {
+				Janus.vdebug("Candidate sent!");
+				Janus.vdebug(json);
+				if(json["janus"] !== "ack") {
+					Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+					return;
+				}
+			},
+			error: function(textStatus, errorThrown) {
+				Janus.error(textStatus + ":", errorThrown);	// FIXME
+			}
+		});
+	}
+
+	// Private method to send a data channel message
+	function sendData(handleId, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		var text = callbacks.text;
+		if(text === null || text === undefined) {
+			Janus.warn("Invalid text");
+			callbacks.error("Invalid text");
+			return;
+		}
+		Janus.log("Sending string on data channel: " + text);
+		config.dataChannel.send(text);
+		callbacks.success();
+	}
+
+	// Private method to send a DTMF tone
+	function sendDtmf(handleId, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		if(config.dtmfSender === null || config.dtmfSender === undefined) {
+			// Create the DTMF sender the proper way, if possible
+			if(config.pc !== undefined && config.pc !== null) {
+				var senders = config.pc.getSenders();
+				var audioSender = senders.find(function(sender) {
+					return sender.track && sender.track.kind === 'audio';
+				});
+				if(!audioSender) {
+					Janus.warn("Invalid DTMF configuration (no audio track)");
+					callbacks.error("Invalid DTMF configuration (no audio track)");
+					return;
+				}
+				config.dtmfSender = audioSender.dtmf;
+				if(config.dtmfSender) {
+					Janus.log("Created DTMF Sender");
+					config.dtmfSender.ontonechange = function(tone) { Janus.debug("Sent DTMF tone: " + tone.tone); };
+				}
+			}
+			if(config.dtmfSender === null || config.dtmfSender === undefined) {
+				Janus.warn("Invalid DTMF configuration");
+				callbacks.error("Invalid DTMF configuration");
+				return;
+			}
+		}
+		var dtmf = callbacks.dtmf;
+		if(dtmf === null || dtmf === undefined) {
+			Janus.warn("Invalid DTMF parameters");
+			callbacks.error("Invalid DTMF parameters");
+			return;
+		}
+		var tones = dtmf.tones;
+		if(tones === null || tones === undefined) {
+			Janus.warn("Invalid DTMF string");
+			callbacks.error("Invalid DTMF string");
+			return;
+		}
+		var duration = dtmf.duration;
+		if(duration === null || duration === undefined)
+			duration = 500;	// We choose 500ms as the default duration for a tone
+		var gap = dtmf.gap;
+		if(gap === null || gap === undefined)
+			gap = 50;	// We choose 50ms as the default gap between tones
+		Janus.debug("Sending DTMF string " + tones + " (duration " + duration + "ms, gap " + gap + "ms)");
+		config.dtmfSender.insertDTMF(tones, duration, gap);
+	}
+
+	// Private method to destroy a plugin handle
+	function destroyHandle(handleId, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		var asyncRequest = true;
+		if(callbacks.asyncRequest !== undefined && callbacks.asyncRequest !== null)
+			asyncRequest = (callbacks.asyncRequest === true);
+		Janus.log("Destroying handle " + handleId + " (async=" + asyncRequest + ")");
+		cleanupWebrtc(handleId);
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined || pluginHandle.detached) {
+			// Plugin was already detached by Janus, calling detach again will return a handle not found error, so just exit here
+			delete pluginHandles[handleId];
+			callbacks.success();
+			return;
+		}
+		if(!connected) {
+			Janus.warn("Is the gateway down? (connected=false)");
+			callbacks.error("Is the gateway down? (connected=false)");
+			return;
+		}
+		var request = { "janus": "detach", "transaction": Janus.randomString(12) };
+		if(pluginHandle.token !== null && pluginHandle.token !== undefined)
+			request["token"] = pluginHandle.token;
+		if(apisecret !== null && apisecret !== undefined)
+			request["apisecret"] = apisecret;
+		if(websockets) {
+			request["session_id"] = sessionId;
+			request["handle_id"] = handleId;
+			ws.send(JSON.stringify(request));
+			delete pluginHandles[handleId];
+			callbacks.success();
+			return;
+		}
+		Janus.httpAPICall(server + "/" + sessionId + "/" + handleId, {
+			verb: 'POST',
+			async: asyncRequest,	// Sometimes we need false here, or destroying in onbeforeunload won't work
+			withCredentials: withCredentials,
+			body: request,
+			success: function(json) {
+				Janus.log("Destroyed handle:");
+				Janus.debug(json);
+				if(json["janus"] !== "success") {
+					Janus.error("Ooops: " + json["error"].code + " " + json["error"].reason);	// FIXME
+				}
+				delete pluginHandles[handleId];
+				callbacks.success();
+			},
+			error: function(textStatus, errorThrown) {
+				Janus.error(textStatus + ":", errorThrown);	// FIXME
+				// We cleanup anyway
+				delete pluginHandles[handleId];
+				callbacks.success();
+			}
+		});
+	}
+
+	// WebRTC stuff
+	function streamsDone(handleId, jsep, media, callbacks, stream) {
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		Janus.debug("streamsDone:", stream);
+		if(stream) {
+			Janus.debug("  -- Audio tracks:", stream.getAudioTracks());
+			Janus.debug("  -- Video tracks:", stream.getVideoTracks());
+		}
+		// We're now capturing the new stream: check if we're updating or if it's a new thing
+		var addTracks = false;
+		if(!config.myStream || !media.update || config.streamExternal) {
+			config.myStream = stream;
+			addTracks = true;
+		} else {
+			// We only need to update the existing stream
+			if(((!media.update && isAudioSendEnabled(media)) || (media.update && (media.addAudio || media.replaceAudio))) &&
+					stream.getAudioTracks() && stream.getAudioTracks().length) {
+				config.myStream.addTrack(stream.getAudioTracks()[0]);
+				if(media.replaceAudio && Janus.webRTCAdapter.browserDetails.browser === "firefox") {
+					Janus.log("Replacing audio track:", stream.getAudioTracks()[0]);
+					for(var index in config.pc.getSenders()) {
+						var s = config.pc.getSenders()[index];
+						if(s && s.track && s.track.kind === "audio") {
+							s.replaceTrack(stream.getAudioTracks()[0]);
+						}
+					}
+				} else {
+					if(Janus.webRTCAdapter.browserDetails.browser === "firefox" && Janus.webRTCAdapter.browserDetails.version >= 59) {
+						// Firefox >= 59 uses Transceivers
+						Janus.log((media.replaceVideo ? "Replacing" : "Adding") + " video track:", stream.getVideoTracks()[0]);
+						var audioTransceiver = null;
+						var transceivers = config.pc.getTransceivers();
+						if(transceivers && transceivers.length > 0) {
+							for(var i in transceivers) {
+								var t = transceivers[i];
+								if((t.sender && t.sender.track && t.sender.track.kind === "audio") ||
+										(t.receiver && t.receiver.track && t.receiver.track.kind === "audio")) {
+									audioTransceiver = t;
+									break;
+								}
+							}
+						}
+						if(audioTransceiver && audioTransceiver.sender) {
+							audioTransceiver.sender.replaceTrack(stream.getVideoTracks()[0]);
+						} else {
+							config.pc.addTrack(stream.getVideoTracks()[0], stream);
+						}
+					} else {
+						Janus.log((media.replaceAudio ? "Replacing" : "Adding") + " audio track:", stream.getAudioTracks()[0]);
+						config.pc.addTrack(stream.getAudioTracks()[0], stream);
+					}
+				}
+			}
+			if(((!media.update && isVideoSendEnabled(media)) || (media.update && (media.addVideo || media.replaceVideo))) &&
+					stream.getVideoTracks() && stream.getVideoTracks().length) {
+				config.myStream.addTrack(stream.getVideoTracks()[0]);
+				if(media.replaceVideo && Janus.webRTCAdapter.browserDetails.browser === "firefox") {
+					Janus.log("Replacing video track:", stream.getVideoTracks()[0]);
+					for(var index in config.pc.getSenders()) {
+						var s = config.pc.getSenders()[index];
+						if(s && s.track && s.track.kind === "video") {
+							s.replaceTrack(stream.getVideoTracks()[0]);
+						}
+					}
+				} else {
+					if(Janus.webRTCAdapter.browserDetails.browser === "firefox" && Janus.webRTCAdapter.browserDetails.version >= 59) {
+						// Firefox >= 59 uses Transceivers
+						Janus.log((media.replaceVideo ? "Replacing" : "Adding") + " video track:", stream.getVideoTracks()[0]);
+						var videoTransceiver = null;
+						var transceivers = config.pc.getTransceivers();
+						if(transceivers && transceivers.length > 0) {
+							for(var i in transceivers) {
+								var t = transceivers[i];
+								if((t.sender && t.sender.track && t.sender.track.kind === "video") ||
+										(t.receiver && t.receiver.track && t.receiver.track.kind === "video")) {
+									videoTransceiver = t;
+									break;
+								}
+							}
+						}
+						if(videoTransceiver && videoTransceiver.sender) {
+							videoTransceiver.sender.replaceTrack(stream.getVideoTracks()[0]);
+						} else {
+							config.pc.addTrack(stream.getVideoTracks()[0], stream);
+						}
+					} else {
+						Janus.log((media.replaceVideo ? "Replacing" : "Adding") + " video track:", stream.getVideoTracks()[0]);
+						config.pc.addTrack(stream.getVideoTracks()[0], stream);
+					}
+				}
+			}
+		}
+		// If we still need to create a PeerConnection, let's do that
+		if(!config.pc) {
+			var pc_config = {"iceServers": iceServers, "iceTransportPolicy": iceTransportPolicy, "bundlePolicy": bundlePolicy};
+			//~ var pc_constraints = {'mandatory': {'MozDontOfferDataChannel':true}};
+			var pc_constraints = {
+				"optional": [{"DtlsSrtpKeyAgreement": true}]
+			};
+			if(ipv6Support === true) {
+				// FIXME This is only supported in Chrome right now
+				// For support in Firefox track this: https://bugzilla.mozilla.org/show_bug.cgi?id=797262
+				pc_constraints.optional.push({"googIPv6":true});
+			}
+			// Any custom constraint to add?
+			if(callbacks.rtcConstraints && typeof callbacks.rtcConstraints === 'object') {
+				Janus.debug("Adding custom PeerConnection constraints:", callbacks.rtcConstraints);
+				for(var i in callbacks.rtcConstraints) {
+					pc_constraints.optional.push(callbacks.rtcConstraints[i]);
+				}
+			}
+			if(Janus.webRTCAdapter.browserDetails.browser === "edge") {
+				// This is Edge, enable BUNDLE explicitly
+				pc_config.bundlePolicy = "max-bundle";
+			}
+			Janus.log("Creating PeerConnection");
+			Janus.debug(pc_constraints);
+			config.pc = new RTCPeerConnection(pc_config, pc_constraints);
+			Janus.debug(config.pc);
+			if(config.pc.getStats) {	// FIXME
+				config.volume.value = 0;
+				config.bitrate.value = "0 kbits/sec";
+			}
+			Janus.log("Preparing local SDP and gathering candidates (trickle=" + config.trickle + ")");
+			config.pc.oniceconnectionstatechange = function(e) {
+				if(config.pc)
+					pluginHandle.iceState(config.pc.iceConnectionState);
+			};
+			config.pc.onicecandidate = function(event) {
+				if (event.candidate == null ||
+						(Janus.webRTCAdapter.browserDetails.browser === 'edge' && event.candidate.candidate.indexOf('endOfCandidates') > 0)) {
+					Janus.log("End of candidates.");
+					config.iceDone = true;
+					if(config.trickle === true) {
+						// Notify end of candidates
+						sendTrickleCandidate(handleId, {"completed": true});
+					} else {
+						// No trickle, time to send the complete SDP (including all candidates)
+						sendSDP(handleId, callbacks);
+					}
+				} else {
+					// JSON.stringify doesn't work on some WebRTC objects anymore
+					// See https://code.google.com/p/chromium/issues/detail?id=467366
+					var candidate = {
+						"candidate": event.candidate.candidate,
+						"sdpMid": event.candidate.sdpMid,
+						"sdpMLineIndex": event.candidate.sdpMLineIndex
+					};
+					if(config.trickle === true) {
+						// Send candidate
+						sendTrickleCandidate(handleId, candidate);
+					}
+				}
+			};
+			config.pc.ontrack = function(event) {
+				Janus.log("Handling Remote Track");
+				Janus.debug(event);
+				if(!event.streams)
+					return;
+				config.remoteStream = event.streams[0];
+				pluginHandle.onremotestream(config.remoteStream);
+				if(event.track && !event.track.onended) {
+					Janus.log("Adding onended callback to track:", event.track);
+					event.track.onended = function(ev) {
+						Janus.log("Remote track removed:", ev);
+						if(config.remoteStream) {
+							config.remoteStream.removeTrack(ev.target);
+							pluginHandle.onremotestream(config.remoteStream);
+						}
+					}
+				}
+			};
+		}
+		if(addTracks && stream !== null && stream !== undefined) {
+			Janus.log('Adding local stream');
+			stream.getTracks().forEach(function(track) {
+				Janus.log('Adding local track:', track);
+				config.pc.addTrack(track, stream);
+			});
+		}
+		// Any data channel to create?
+		if(isDataEnabled(media) && !config.dataChannel) {
+			Janus.log("Creating data channel");
+			var onDataChannelMessage = function(event) {
+				Janus.log('Received message on data channel: ' + event.data);
+				pluginHandle.ondata(event.data);	// FIXME
+			}
+			var onDataChannelStateChange = function() {
+				var dcState = config.dataChannel !== null ? config.dataChannel.readyState : "null";
+				Janus.log('State change on data channel: ' + dcState);
+				if(dcState === 'open') {
+					pluginHandle.ondataopen();	// FIXME
+				}
+			}
+			var onDataChannelError = function(error) {
+				Janus.error('Got error on data channel:', error);
+				// TODO
+			}
+			// Until we implement the proxying of open requests within the Janus core, we open a channel ourselves whatever the case
+			config.dataChannel = config.pc.createDataChannel("JanusDataChannel", {ordered:false});	// FIXME Add options (ordered, maxRetransmits, etc.)
+			config.dataChannel.onmessage = onDataChannelMessage;
+			config.dataChannel.onopen = onDataChannelStateChange;
+			config.dataChannel.onclose = onDataChannelStateChange;
+			config.dataChannel.onerror = onDataChannelError;
+		}
+		// If there's a new local stream, let's notify the application
+		if(config.myStream)
+			pluginHandle.onlocalstream(config.myStream);
+		// Create offer/answer now
+		if(jsep === null || jsep === undefined) {
+			createOffer(handleId, media, callbacks);
+		} else {
+			config.pc.setRemoteDescription(
+					new RTCSessionDescription(jsep),
+					function() {
+						Janus.log("Remote description accepted!");
+						config.remoteSdp = jsep.sdp;
+						// Any trickle candidate we cached?
+						if(config.candidates && config.candidates.length > 0) {
+							for(var i in config.candidates) {
+								var candidate = config.candidates[i];
+								Janus.debug("Adding remote candidate:", candidate);
+								if(!candidate || candidate.completed === true) {
+									// end-of-candidates
+									config.pc.addIceCandidate();
+								} else {
+									// New candidate
+									config.pc.addIceCandidate(new RTCIceCandidate(candidate));
+								}
+							}
+							config.candidates = [];
+						}
+						// Create the answer now
+						createAnswer(handleId, media, callbacks);
+					}, callbacks.error);
+		}
+	}
+
+	function prepareWebrtc(handleId, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : webrtcError;
+		var jsep = callbacks.jsep;
+		callbacks.media = callbacks.media || { audio: true, video: true };
+		var media = callbacks.media;
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		config.trickle = isTrickleEnabled(callbacks.trickle);
+		// Are we updating a session?
+		if(config.pc === undefined || config.pc === null) {
+			// Nope, new PeerConnection
+			media.update = false;
+		} else if(config.pc !== undefined && config.pc !== null) {
+			Janus.log("Updating existing media session");
+			media.update = true;
+			// Check if there's anything do add/remove/replace, or if we
+			// can go directly to preparing the new SDP offer or answer
+			if(callbacks.stream !== null && callbacks.stream !== undefined) {
+				// External stream: is this the same as the one we were using before?
+				if(callbacks.stream !== config.myStream) {
+					Janus.log("Renegotiation involves a new external stream");
+				}
+			} else {
+				// Check if there are changes on audio
+				if(media.addAudio) {
+					media.replaceAudio = false;
+					media.removeAudio = false;
+					media.audioSend = true;
+					if(config.myStream && config.myStream.getAudioTracks() && config.myStream.getAudioTracks().length) {
+						Janus.error("Can't add audio stream, there already is one");
+						callbacks.error("Can't add audio stream, there already is one");
+						return;
+					}
+				} else if(media.removeAudio) {
+					media.replaceAudio = false;
+					media.addAudio = false;
+					media.audioSend = false;
+				} else if(media.replaceAudio) {
+					media.addAudio = false;
+					media.removeAudio = false;
+					media.audioSend = true;
+				}
+				if(config.myStream === null || config.myStream === undefined) {
+					// No media stream: if we were asked to replace, it's actually an "add"
+					if(media.replaceAudio) {
+						media.replaceAudio = false;
+						media.addAudio = true;
+						media.audioSend = true;
+					}
+					if(isAudioSendEnabled(media))
+						media.addAudio = true;
+				} else {
+					if(config.myStream.getAudioTracks() === null
+							|| config.myStream.getAudioTracks() === undefined
+							|| config.myStream.getAudioTracks().length === 0) {
+						// No audio track: if we were asked to replace, it's actually an "add"
+						if(media.replaceAudio) {
+							media.replaceAudio = false;
+							media.addAudio = true;
+							media.audioSend = true;
+						}
+						if(isAudioSendEnabled(media))
+							media.addAudio = true;
+					}
+				}
+				// Check if there are changes on video
+				if(media.addVideo) {
+					media.replaceVideo = false;
+					media.removeVideo = false;
+					media.videoSend = true;
+					if(config.myStream && config.myStream.getVideoTracks() && config.myStream.getVideoTracks().length) {
+						Janus.error("Can't add video stream, there already is one");
+						callbacks.error("Can't add video stream, there already is one");
+						return;
+					}
+				} else if(media.removeVideo) {
+					media.replaceVideo = false;
+					media.addVideo = false;
+					media.videoSend = false;
+				} else if(media.replaceVideo) {
+					media.addVideo = false;
+					media.removeVideo = false;
+					media.videoSend = true;
+				}
+				if(config.myStream === null || config.myStream === undefined) {
+					// No media stream: if we were asked to replace, it's actually an "add"
+					if(media.replaceVideo) {
+						media.replaceVideo = false;
+						media.addVideo = true;
+						media.videoSend = true;
+					}
+					if(isVideoSendEnabled(media))
+						media.addVideo = true;
+				} else {
+					if(config.myStream.getVideoTracks() === null
+							|| config.myStream.getVideoTracks() === undefined
+							|| config.myStream.getVideoTracks().length === 0) {
+						// No video track: if we were asked to replace, it's actually an "add"
+						if(media.replaceVideo) {
+							media.replaceVideo = false;
+							media.addVideo = true;
+							media.videoSend = true;
+						}
+						if(isVideoSendEnabled(media))
+							media.addVideo = true;
+					}
+				}
+				// Data channels can only be added
+				if(media.addData)
+					media.data = true;
+			}
+		}
+		// If we're updating, check if we need to remove/replace one of the tracks
+		if(media.update && !config.streamExternal) {
+			if(media.removeAudio || media.replaceAudio) {
+				if(config.myStream && config.myStream.getAudioTracks() && config.myStream.getAudioTracks().length) {
+					var s = config.myStream.getAudioTracks()[0];
+					Janus.log("Removing audio track:", s);
+					config.myStream.removeTrack(s);
+					try {
+						s.stop();
+					} catch(e) {};
+				}
+				if(config.pc.getSenders() && config.pc.getSenders().length) {
+					var ra = true;
+					if(media.replaceAudio && Janus.webRTCAdapter.browserDetails.browser === "firefox") {
+						// On Firefox we can use replaceTrack
+						ra = false;
+					}
+					if(ra) {
+						for(var index in config.pc.getSenders()) {
+							var s = config.pc.getSenders()[index];
+							if(s && s.track && s.track.kind === "audio") {
+								Janus.log("Removing audio sender:", s);
+								config.pc.removeTrack(s);
+							}
+						}
+					}
+				}
+			}
+			if(media.removeVideo || media.replaceVideo) {
+				if(config.myStream && config.myStream.getVideoTracks() && config.myStream.getVideoTracks().length) {
+					var s = config.myStream.getVideoTracks()[0];
+					Janus.log("Removing video track:", s);
+					config.myStream.removeTrack(s);
+					try {
+						s.stop();
+					} catch(e) {};
+				}
+				if(config.pc.getSenders() && config.pc.getSenders().length) {
+					var rv = true;
+					if(media.replaceVideo && Janus.webRTCAdapter.browserDetails.browser === "firefox") {
+						// On Firefox we can use replaceTrack
+						rv = false;
+					}
+					if(rv) {
+						for(var index in config.pc.getSenders()) {
+							var s = config.pc.getSenders()[index];
+							if(s && s.track && s.track.kind === "video") {
+								Janus.log("Removing video sender:", s);
+								config.pc.removeTrack(s);
+							}
+						}
+					}
+				}
+			}
+		}
+		// Was a MediaStream object passed, or do we need to take care of that?
+		if(callbacks.stream !== null && callbacks.stream !== undefined) {
+			var stream = callbacks.stream;
+			Janus.log("MediaStream provided by the application");
+			Janus.debug(stream);
+			// If this is an update, let's check if we need to release the previous stream
+			if(media.update) {
+				if(config.myStream && config.myStream !== callbacks.stream && !config.streamExternal) {
+					// We're replacing a stream we captured ourselves with an external one
+					try {
+						// Try a MediaStreamTrack.stop() for each track
+						var tracks = config.myStream.getTracks();
+						for(var i in tracks) {
+							var mst = tracks[i];
+							Janus.log(mst);
+							if(mst !== null && mst !== undefined)
+								mst.stop();
+						}
+					} catch(e) {
+						// Do nothing if this fails
+					}
+					config.myStream = null;
+				}
+			}
+			// Skip the getUserMedia part
+			config.streamExternal = true;
+			streamsDone(handleId, jsep, media, callbacks, stream);
+			return;
+		}
+		if(isAudioSendEnabled(media) || isVideoSendEnabled(media)) {
+			var constraints = { mandatory: {}, optional: []};
+			pluginHandle.consentDialog(true);
+			var audioSupport = isAudioSendEnabled(media);
+			if(audioSupport === true && media != undefined && media != null) {
+				if(typeof media.audio === 'object') {
+					audioSupport = media.audio;
+				}
+			}
+			var videoSupport = isVideoSendEnabled(media);
+			if(videoSupport === true && media != undefined && media != null) {
+				var simulcast = callbacks.simulcast === true ? true : false;
+				if(simulcast && !jsep && (media.video === undefined || media.video === false))
+					media.video = "hires";
+				if(media.video && media.video != 'screen' && media.video != 'window') {
+					if(typeof media.video === 'object') {
+						videoSupport = media.video;
+					} else {
+						var width = 0;
+						var height = 0, maxHeight = 0;
+						if(media.video === 'lowres') {
+							// Small resolution, 4:3
+							height = 240;
+							maxHeight = 240;
+							width = 320;
+						} else if(media.video === 'lowres-16:9') {
+							// Small resolution, 16:9
+							height = 180;
+							maxHeight = 180;
+							width = 320;
+						} else if(media.video === 'hires' || media.video === 'hires-16:9' ) {
+							// High resolution is only 16:9
+							height = 720;
+							maxHeight = 720;
+							width = 1280;
+						} else if(media.video === 'stdres') {
+							// Normal resolution, 4:3
+							height = 480;
+							maxHeight = 480;
+							width  = 640;
+						} else if(media.video === 'stdres-16:9') {
+							// Normal resolution, 16:9
+							height = 360;
+							maxHeight = 360;
+							width = 640;
+						} else {
+							Janus.log("Default video setting is stdres 4:3");
+							height = 480;
+							maxHeight = 480;
+							width = 640;
+						}
+						Janus.log("Adding media constraint:", media.video);
+						videoSupport = {
+							'height': {'ideal': height},
+							'width':  {'ideal': width}
+						};
+						Janus.log("Adding video constraint:", videoSupport);
+					}
+				} else if(media.video === 'screen' || media.video === 'window') {
+					if(!media.screenshareFrameRate) {
+						media.screenshareFrameRate = 3;
+					}
+					// Not a webcam, but screen capture
+					if(window.location.protocol !== 'https:') {
+						// Screen sharing mandates HTTPS
+						Janus.warn("Screen sharing only works on HTTPS, try the https:// version of this page");
+						pluginHandle.consentDialog(false);
+						callbacks.error("Screen sharing only works on HTTPS, try the https:// version of this page");
+						return;
+					}
+					// We're going to try and use the extension for Chrome 34+, the old approach
+					// for older versions of Chrome, or the experimental support in Firefox 33+
+					var cache = {};
+					function callbackUserMedia (error, stream) {
+						pluginHandle.consentDialog(false);
+						if(error) {
+							callbacks.error({code: error.code, name: error.name, message: error.message});
+						} else {
+							streamsDone(handleId, jsep, media, callbacks, stream);
+						}
+					};
+					function getScreenMedia(constraints, gsmCallback, useAudio) {
+						Janus.log("Adding media constraint (screen capture)");
+						Janus.debug(constraints);
+						navigator.mediaDevices.getUserMedia(constraints)
+							.then(function(stream) {
+								if(useAudio){
+									navigator.mediaDevices.getUserMedia({ audio: true, video: false })
+									.then(function (audioStream) {
+										stream.addTrack(audioStream.getAudioTracks()[0]);
+										gsmCallback(null, stream);
+									})
+								} else {
+									gsmCallback(null, stream);
+								}
+							})
+							.catch(function(error) { pluginHandle.consentDialog(false); gsmCallback(error); });
+					};
+					if(Janus.webRTCAdapter.browserDetails.browser === 'chrome') {
+						var chromever = Janus.webRTCAdapter.browserDetails.version;
+						var maxver = 33;
+						if(window.navigator.userAgent.match('Linux'))
+							maxver = 35;	// "known" crash in chrome 34 and 35 on linux
+						if(chromever >= 26 && chromever <= maxver) {
+							// Chrome 26->33 requires some awkward chrome://flags manipulation
+							constraints = {
+								video: {
+									mandatory: {
+										googLeakyBucket: true,
+										maxWidth: window.screen.width,
+										maxHeight: window.screen.height,
+										minFrameRate: media.screenshareFrameRate,
+										maxFrameRate: media.screenshareFrameRate,
+										chromeMediaSource: 'screen'
+									}
+								},
+								audio: isAudioSendEnabled(media)
+							};
+							getScreenMedia(constraints, callbackUserMedia);
+						} else {
+							// Chrome 34+ requires an extension
+							var pending = window.setTimeout(
+								function () {
+									error = new Error('NavigatorUserMediaError');
+									error.name = 'The required Chrome extension is not installed: click <a href="#">here</a> to install it. (NOTE: this will need you to refresh the page)';
+									pluginHandle.consentDialog(false);
+									return callbacks.error(error);
+								}, 1000);
+							cache[pending] = [callbackUserMedia, null];
+							window.postMessage({ type: 'janusGetScreen', id: pending }, '*');
+						}
+					} else if (window.navigator.userAgent.match('Firefox')) {
+						var ffver = parseInt(window.navigator.userAgent.match(/Firefox\/(.*)/)[1], 10);
+						if(ffver >= 33) {
+							// Firefox 33+ has experimental support for screen sharing
+							constraints = {
+								video: {
+									mozMediaSource: media.video,
+									mediaSource: media.video
+								},
+								audio: isAudioSendEnabled(media)
+							};
+							getScreenMedia(constraints, function (err, stream) {
+								callbackUserMedia(err, stream);
+								// Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1045810
+								if (!err) {
+									var lastTime = stream.currentTime;
+									var polly = window.setInterval(function () {
+										if(!stream)
+											window.clearInterval(polly);
+										if(stream.currentTime == lastTime) {
+											window.clearInterval(polly);
+											if(stream.onended) {
+												stream.onended();
+											}
+										}
+										lastTime = stream.currentTime;
+									}, 500);
+								}
+							});
+						} else {
+							var error = new Error('NavigatorUserMediaError');
+							error.name = 'Your version of Firefox does not support screen sharing, please install Firefox 33 (or more recent versions)';
+							pluginHandle.consentDialog(false);
+							callbacks.error(error);
+							return;
+						}
+					}
+
+					// Wait for events from the Chrome Extension
+					window.addEventListener('message', function (event) {
+						if(event.origin != window.location.origin)
+							return;
+						if(event.data.type == 'janusGotScreen' && cache[event.data.id]) {
+							var data = cache[event.data.id];
+							var callback = data[0];
+							delete cache[event.data.id];
+
+							if (event.data.sourceId === '') {
+								// user canceled
+								var error = new Error('NavigatorUserMediaError');
+								error.name = 'You cancelled the request for permission, giving up...';
+								pluginHandle.consentDialog(false);
+								callbacks.error(error);
+							} else {
+								constraints = {
+									audio: false,
+									video: {
+										mandatory: {
+											chromeMediaSource: 'desktop',
+											maxWidth: window.screen.width,
+											maxHeight: window.screen.height,
+											minFrameRate: media.screenshareFrameRate,
+											maxFrameRate: media.screenshareFrameRate,
+										},
+										optional: [
+											{googLeakyBucket: true},
+											{googTemporalLayeredScreencast: true}
+										]
+									}
+								};
+								constraints.video.mandatory.chromeMediaSourceId = event.data.sourceId;
+								getScreenMedia(constraints, callback, isAudioSendEnabled(media));
+							}
+						} else if (event.data.type == 'janusGetScreenPending') {
+							window.clearTimeout(event.data.id);
+						}
+					});
+					return;
+				}
+			}
+			// If we got here, we're not screensharing
+			if(media === null || media === undefined || media.video !== 'screen') {
+				// Check whether all media sources are actually available or not
+				navigator.mediaDevices.enumerateDevices().then(function(devices) {
+					var audioExist = devices.some(function(device) {
+						return device.kind === 'audioinput';
+					}),
+					videoExist = devices.some(function(device) {
+						return device.kind === 'videoinput';
+					});
+
+					// Check whether a missing device is really a problem
+					var audioSend = isAudioSendEnabled(media);
+					var videoSend = isVideoSendEnabled(media);
+					var needAudioDevice = isAudioSendRequired(media);
+					var needVideoDevice = isVideoSendRequired(media);
+					if(audioSend || videoSend || needAudioDevice || needVideoDevice) {
+						// We need to send either audio or video
+						var haveAudioDevice = audioSend ? audioExist : false;
+						var haveVideoDevice = videoSend ? videoExist : false;
+						if(!haveAudioDevice && !haveVideoDevice) {
+							// FIXME Should we really give up, or just assume recvonly for both?
+							pluginHandle.consentDialog(false);
+							callbacks.error('No capture device found');
+							return false;
+						} else if(!haveAudioDevice && needAudioDevice) {
+							pluginHandle.consentDialog(false);
+							callbacks.error('Audio capture is required, but no capture device found');
+							return false;
+						} else if(!haveVideoDevice && needVideoDevice) {
+							pluginHandle.consentDialog(false);
+							callbacks.error('Video capture is required, but no capture device found');
+							return false;
+						}
+					}
+
+					var gumConstraints = {
+						audio: audioExist ? audioSupport : false,
+						video: videoExist ? videoSupport : false
+					};
+					Janus.debug("getUserMedia constraints", gumConstraints);
+					navigator.mediaDevices.getUserMedia(gumConstraints)
+					.then(function(stream) { pluginHandle.consentDialog(false); streamsDone(handleId, jsep, media, callbacks, stream); })
+					.catch(function(error) { pluginHandle.consentDialog(false); callbacks.error({code: error.code, name: error.name, message: error.message}); });
+				})
+				.catch(function(error) {
+					pluginHandle.consentDialog(false);
+					callbacks.error('enumerateDevices error', error);
+				});
+			}
+		} else {
+			// No need to do a getUserMedia, create offer/answer right away
+			streamsDone(handleId, jsep, media, callbacks);
+		}
+	}
+
+	function prepareWebrtcPeer(handleId, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : webrtcError;
+		var jsep = callbacks.jsep;
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		if(jsep !== undefined && jsep !== null) {
+			if(config.pc === null) {
+				Janus.warn("Wait, no PeerConnection?? if this is an answer, use createAnswer and not handleRemoteJsep");
+				callbacks.error("No PeerConnection: if this is an answer, use createAnswer and not handleRemoteJsep");
+				return;
+			}
+			config.pc.setRemoteDescription(
+					new RTCSessionDescription(jsep),
+					function() {
+						Janus.log("Remote description accepted!");
+						config.remoteSdp = jsep.sdp;
+						// Any trickle candidate we cached?
+						if(config.candidates && config.candidates.length > 0) {
+							for(var i in config.candidates) {
+								var candidate = config.candidates[i];
+								Janus.debug("Adding remote candidate:", candidate);
+								if(!candidate || candidate.completed === true) {
+									// end-of-candidates
+									config.pc.addIceCandidate();
+								} else {
+									// New candidate
+									config.pc.addIceCandidate(new RTCIceCandidate(candidate));
+								}
+							}
+							config.candidates = [];
+						}
+						// Done
+						callbacks.success();
+					}, callbacks.error);
+		} else {
+			callbacks.error("Invalid JSEP");
+		}
+	}
+
+	function createOffer(handleId, media, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		var simulcast = callbacks.simulcast === true ? true : false;
+		if(!simulcast) {
+			Janus.log("Creating offer (iceDone=" + config.iceDone + ")");
+		} else {
+			Janus.log("Creating offer (iceDone=" + config.iceDone + ", simulcast=" + simulcast + ")");
+		}
+		// https://code.google.com/p/webrtc/issues/detail?id=3508
+		var mediaConstraints = {};
+		if(Janus.webRTCAdapter.browserDetails.browser === "firefox" && Janus.webRTCAdapter.browserDetails.version >= 59) {
+			// Firefox >= 59 uses Transceivers
+			var audioTransceiver = null, videoTransceiver = null;
+			var transceivers = config.pc.getTransceivers();
+			if(transceivers && transceivers.length > 0) {
+				for(var i in transceivers) {
+					var t = transceivers[i];
+					if((t.sender && t.sender.track && t.sender.track.kind === "audio") ||
+							(t.receiver && t.receiver.track && t.receiver.track.kind === "audio")) {
+						if(!audioTransceiver)
+							audioTransceiver = t;
+						continue;
+					}
+					if((t.sender && t.sender.track && t.sender.track.kind === "video") ||
+							(t.receiver && t.receiver.track && t.receiver.track.kind === "video")) {
+						if(!videoTransceiver)
+							videoTransceiver = t;
+						continue;
+					}
+				}
+			}
+			// Handle audio (and related changes, if any)
+			var audioSend = isAudioSendEnabled(media);
+			var audioRecv = isAudioRecvEnabled(media);
+			if(!audioSend && !audioRecv) {
+				// Audio disabled: have we removed it?
+				if(media.removeAudio && audioTransceiver) {
+					audioTransceiver.direction = "inactive";
+					Janus.log("Setting audio transceiver to inactive:", audioTransceiver);
+				}
+			} else {
+				// Take care of audio m-line
+				if(audioSend && audioRecv) {
+					if(audioTransceiver) {
+						audioTransceiver.direction = "sendrecv";
+						Janus.log("Setting audio transceiver to sendrecv:", audioTransceiver);
+					}
+				} else if(audioSend && !audioRecv) {
+					if(audioTransceiver) {
+						audioTransceiver.direction = "sendonly";
+						Janus.log("Setting audio transceiver to sendonly:", audioTransceiver);
+					}
+				} else if(!audioSend && audioRecv) {
+					if(audioTransceiver) {
+						audioTransceiver.direction = "recvonly";
+						Janus.log("Setting audio transceiver to recvonly:", audioTransceiver);
+					} else {
+						// In theory, this is the only case where we might not have a transceiver yet
+						audioTransceiver = config.pc.addTransceiver("audio", { direction: "recvonly" });
+						Janus.log("Adding recvonly audio transceiver:", audioTransceiver);
+					}
+				}
+			}
+			// Handle video (and related changes, if any)
+			var videoSend = isVideoSendEnabled(media);
+			var videoRecv = isVideoRecvEnabled(media);
+			if(!videoSend && !videoRecv) {
+				// Video disabled: have we removed it?
+				if(media.removeVideo && videoTransceiver) {
+					videoTransceiver.direction = "inactive";
+					Janus.log("Setting video transceiver to inactive:", videoTransceiver);
+				}
+			} else {
+				// Take care of video m-line
+				if(videoSend && videoRecv) {
+					if(videoTransceiver) {
+						videoTransceiver.direction = "sendrecv";
+						Janus.log("Setting video transceiver to sendrecv:", videoTransceiver);
+					}
+				} else if(videoSend && !videoRecv) {
+					if(videoTransceiver) {
+						videoTransceiver.direction = "sendonly";
+						Janus.log("Setting video transceiver to sendonly:", videoTransceiver);
+					}
+				} else if(!videoSend && videoRecv) {
+					if(videoTransceiver) {
+						videoTransceiver.direction = "recvonly";
+						Janus.log("Setting video transceiver to recvonly:", videoTransceiver);
+					} else {
+						// In theory, this is the only case where we might not have a transceiver yet
+						videoTransceiver = config.pc.addTransceiver("video", { direction: "recvonly" });
+						Janus.log("Adding recvonly video transceiver:", videoTransceiver);
+					}
+				}
+			}
+		} else {
+			mediaConstraints["offerToReceiveAudio"] = isAudioRecvEnabled(media);
+			mediaConstraints["offerToReceiveVideo"] = isVideoRecvEnabled(media);
+		}
+		var iceRestart = callbacks.iceRestart === true ? true : false;
+		if(iceRestart) {
+			mediaConstraints["iceRestart"] = true;
+		}
+		Janus.debug(mediaConstraints);
+		// Check if this is Firefox and we've been asked to do simulcasting
+		var sendVideo = isVideoSendEnabled(media);
+		if(sendVideo && simulcast && Janus.webRTCAdapter.browserDetails.browser === "firefox") {
+			// FIXME Based on https://gist.github.com/voluntas/088bc3cc62094730647b
+			Janus.log("Enabling Simulcasting for Firefox (RID)");
+			var sender = config.pc.getSenders()[1];
+			Janus.log(sender);
+			var parameters = sender.getParameters();
+			Janus.log(parameters);
+			sender.setParameters({encodings: [
+				{ rid: "high", active: true, priority: "high", maxBitrate: 1000000 },
+				{ rid: "medium", active: true, priority: "medium", maxBitrate: 300000 },
+				{ rid: "low", active: true, priority: "low", maxBitrate: 100000 }
+			]});
+		}
+		config.pc.createOffer(
+			function(offer) {
+				Janus.debug(offer);
+				Janus.log("Setting local description");
+				if(sendVideo && simulcast) {
+					// This SDP munging only works with Chrome
+					if(Janus.webRTCAdapter.browserDetails.browser === "chrome") {
+						Janus.log("Enabling Simulcasting for Chrome (SDP munging)");
+						offer.sdp = mungeSdpForSimulcasting(offer.sdp);
+					} else if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
+						Janus.warn("simulcast=true, but this is not Chrome nor Firefox, ignoring");
+					}
+				}
+				config.mySdp = offer.sdp;
+				config.pc.setLocalDescription(offer);
+				config.mediaConstraints = mediaConstraints;
+				if(!config.iceDone && !config.trickle) {
+					// Don't do anything until we have all candidates
+					Janus.log("Waiting for all candidates...");
+					return;
+				}
+				Janus.log("Offer ready");
+				Janus.debug(callbacks);
+				// JSON.stringify doesn't work on some WebRTC objects anymore
+				// See https://code.google.com/p/chromium/issues/detail?id=467366
+				var jsep = {
+					"type": offer.type,
+					"sdp": offer.sdp
+				};
+				callbacks.success(jsep);
+			}, callbacks.error, mediaConstraints);
+	}
+
+	function createAnswer(handleId, media, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			callbacks.error("Invalid handle");
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		var simulcast = callbacks.simulcast === true ? true : false;
+		if(!simulcast) {
+			Janus.log("Creating answer (iceDone=" + config.iceDone + ")");
+		} else {
+			Janus.log("Creating answer (iceDone=" + config.iceDone + ", simulcast=" + simulcast + ")");
+		}
+		var mediaConstraints = null;
+		if(Janus.webRTCAdapter.browserDetails.browser === "firefox" && Janus.webRTCAdapter.browserDetails.version >= 59) {
+			// Firefox >= 59 uses Transceivers
+			mediaConstraints = {};
+			var audioTransceiver = null, videoTransceiver = null;
+			var transceivers = config.pc.getTransceivers();
+			if(transceivers && transceivers.length > 0) {
+				for(var i in transceivers) {
+					var t = transceivers[i];
+					if((t.sender && t.sender.track && t.sender.track.kind === "audio") ||
+							(t.receiver && t.receiver.track && t.receiver.track.kind === "audio")) {
+						if(!audioTransceiver)
+							audioTransceiver = t;
+						continue;
+					}
+					if((t.sender && t.sender.track && t.sender.track.kind === "video") ||
+							(t.receiver && t.receiver.track && t.receiver.track.kind === "video")) {
+						if(!videoTransceiver)
+							videoTransceiver = t;
+						continue;
+					}
+				}
+			}
+			// Handle audio (and related changes, if any)
+			var audioSend = isAudioSendEnabled(media);
+			var audioRecv = isAudioRecvEnabled(media);
+			if(!audioSend && !audioRecv) {
+				// Audio disabled: have we removed it?
+				if(media.removeAudio && audioTransceiver) {
+					audioTransceiver.direction = "inactive";
+					Janus.log("Setting audio transceiver to inactive:", audioTransceiver);
+				}
+			} else {
+				// Take care of audio m-line
+				if(audioSend && audioRecv) {
+					if(audioTransceiver) {
+						audioTransceiver.direction = "sendrecv";
+						Janus.log("Setting audio transceiver to sendrecv:", audioTransceiver);
+					}
+				} else if(audioSend && !audioRecv) {
+					if(audioTransceiver) {
+						audioTransceiver.direction = "sendonly";
+						Janus.log("Setting audio transceiver to sendonly:", audioTransceiver);
+					}
+				} else if(!audioSend && audioRecv) {
+					if(audioTransceiver) {
+						audioTransceiver.direction = "recvonly";
+						Janus.log("Setting audio transceiver to recvonly:", audioTransceiver);
+					} else {
+						// In theory, this is the only case where we might not have a transceiver yet
+						audioTransceiver = config.pc.addTransceiver("audio", { direction: "recvonly" });
+						Janus.log("Adding recvonly audio transceiver:", audioTransceiver);
+					}
+				}
+			}
+			// Handle video (and related changes, if any)
+			var videoSend = isVideoSendEnabled(media);
+			var videoRecv = isVideoRecvEnabled(media);
+			if(!videoSend && !videoRecv) {
+				// Video disabled: have we removed it?
+				if(media.removeVideo && videoTransceiver) {
+					videoTransceiver.direction = "inactive";
+					Janus.log("Setting video transceiver to inactive:", videoTransceiver);
+				}
+			} else {
+				// Take care of video m-line
+				if(videoSend && videoRecv) {
+					if(videoTransceiver) {
+						videoTransceiver.direction = "sendrecv";
+						Janus.log("Setting video transceiver to sendrecv:", videoTransceiver);
+					}
+				} else if(videoSend && !videoRecv) {
+					if(videoTransceiver) {
+						videoTransceiver.direction = "sendonly";
+						Janus.log("Setting video transceiver to sendonly:", videoTransceiver);
+					}
+				} else if(!videoSend && videoRecv) {
+					if(videoTransceiver) {
+						videoTransceiver.direction = "recvonly";
+						Janus.log("Setting video transceiver to recvonly:", videoTransceiver);
+					} else {
+						// In theory, this is the only case where we might not have a transceiver yet
+						videoTransceiver = config.pc.addTransceiver("video", { direction: "recvonly" });
+						Janus.log("Adding recvonly video transceiver:", videoTransceiver);
+					}
+				}
+			}
+		} else {
+			if(Janus.webRTCAdapter.browserDetails.browser == "firefox" || Janus.webRTCAdapter.browserDetails.browser == "edge") {
+				mediaConstraints = {
+					offerToReceiveAudio: isAudioRecvEnabled(media),
+					offerToReceiveVideo: isVideoRecvEnabled(media)
+				};
+			} else {
+				mediaConstraints = {
+					mandatory: {
+						OfferToReceiveAudio: isAudioRecvEnabled(media),
+						OfferToReceiveVideo: isVideoRecvEnabled(media)
+					}
+				};
+			}
+		}
+		Janus.debug(mediaConstraints);
+		// Check if this is Firefox and we've been asked to do simulcasting
+		var sendVideo = isVideoSendEnabled(media);
+		if(sendVideo && simulcast && Janus.webRTCAdapter.browserDetails.browser === "firefox") {
+			// FIXME Based on https://gist.github.com/voluntas/088bc3cc62094730647b
+			Janus.log("Enabling Simulcasting for Firefox (RID)");
+			var sender = config.pc.getSenders()[1];
+			Janus.log(sender);
+			var parameters = sender.getParameters();
+			Janus.log(parameters);
+			sender.setParameters({encodings: [
+				{ rid: "high", active: true, priority: "high", maxBitrate: 1000000 },
+				{ rid: "medium", active: true, priority: "medium", maxBitrate: 300000 },
+				{ rid: "low", active: true, priority: "low", maxBitrate: 100000 }
+			]});
+		}
+		config.pc.createAnswer(
+			function(answer) {
+				Janus.debug(answer);
+				Janus.log("Setting local description");
+				if(sendVideo && simulcast) {
+					// This SDP munging only works with Chrome
+					if(Janus.webRTCAdapter.browserDetails.browser === "chrome") {
+						// FIXME Apparently trying to simulcast when answering breaks video in Chrome...
+						//~ Janus.log("Enabling Simulcasting for Chrome (SDP munging)");
+						//~ answer.sdp = mungeSdpForSimulcasting(answer.sdp);
+						Janus.warn("simulcast=true, but this is an answer, and video breaks in Chrome if we enable it");
+					} else if(Janus.webRTCAdapter.browserDetails.browser !== "firefox") {
+						Janus.warn("simulcast=true, but this is not Chrome nor Firefox, ignoring");
+					}
+				}
+				config.mySdp = answer.sdp;
+				config.pc.setLocalDescription(answer);
+				config.mediaConstraints = mediaConstraints;
+				if(!config.iceDone && !config.trickle) {
+					// Don't do anything until we have all candidates
+					Janus.log("Waiting for all candidates...");
+					return;
+				}
+				// JSON.stringify doesn't work on some WebRTC objects anymore
+				// See https://code.google.com/p/chromium/issues/detail?id=467366
+				var jsep = {
+					"type": answer.type,
+					"sdp": answer.sdp
+				};
+				callbacks.success(jsep);
+			}, callbacks.error, mediaConstraints);
+	}
+
+	function sendSDP(handleId, callbacks) {
+		callbacks = callbacks || {};
+		callbacks.success = (typeof callbacks.success == "function") ? callbacks.success : Janus.noop;
+		callbacks.error = (typeof callbacks.error == "function") ? callbacks.error : Janus.noop;
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle, not sending anything");
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		Janus.log("Sending offer/answer SDP...");
+		if(config.mySdp === null || config.mySdp === undefined) {
+			Janus.warn("Local SDP instance is invalid, not sending anything...");
+			return;
+		}
+		config.mySdp = {
+			"type": config.pc.localDescription.type,
+			"sdp": config.pc.localDescription.sdp
+		};
+		if(config.trickle === false)
+			config.mySdp["trickle"] = false;
+		Janus.debug(callbacks);
+		config.sdpSent = true;
+		callbacks.success(config.mySdp);
+	}
+
+	function getVolume(handleId) {
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			return 0;
+		}
+		var config = pluginHandle.webrtcStuff;
+		// Start getting the volume, if getStats is supported
+		if(config.pc.getStats && Janus.webRTCAdapter.browserDetails.browser == "chrome") {	// FIXME
+			if(config.remoteStream === null || config.remoteStream === undefined) {
+				Janus.warn("Remote stream unavailable");
+				return 0;
+			}
+			// http://webrtc.googlecode.com/svn/trunk/samples/js/demos/html/constraints-and-stats.html
+			if(config.volume.timer === null || config.volume.timer === undefined) {
+				Janus.log("Starting volume monitor");
+				config.volume.timer = setInterval(function() {
+					config.pc.getStats(function(stats) {
+						var results = stats.result();
+						for(var i=0; i<results.length; i++) {
+							var res = results[i];
+							if(res.type == 'ssrc' && res.stat('audioOutputLevel')) {
+								config.volume.value = res.stat('audioOutputLevel');
+							}
+						}
+					});
+				}, 200);
+				return 0;	// We don't have a volume to return yet
+			}
+			return config.volume.value;
+		} else {
+			Janus.log("Getting the remote volume unsupported by browser");
+			return 0;
+		}
+	}
+
+	function isMuted(handleId, video) {
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			return true;
+		}
+		var config = pluginHandle.webrtcStuff;
+		if(config.pc === null || config.pc === undefined) {
+			Janus.warn("Invalid PeerConnection");
+			return true;
+		}
+		if(config.myStream === undefined || config.myStream === null) {
+			Janus.warn("Invalid local MediaStream");
+			return true;
+		}
+		if(video) {
+			// Check video track
+			if(config.myStream.getVideoTracks() === null
+					|| config.myStream.getVideoTracks() === undefined
+					|| config.myStream.getVideoTracks().length === 0) {
+				Janus.warn("No video track");
+				return true;
+			}
+			return !config.myStream.getVideoTracks()[0].enabled;
+		} else {
+			// Check audio track
+			if(config.myStream.getAudioTracks() === null
+					|| config.myStream.getAudioTracks() === undefined
+					|| config.myStream.getAudioTracks().length === 0) {
+				Janus.warn("No audio track");
+				return true;
+			}
+			return !config.myStream.getAudioTracks()[0].enabled;
+		}
+	}
+
+	function mute(handleId, video, mute) {
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			return false;
+		}
+		var config = pluginHandle.webrtcStuff;
+		if(config.pc === null || config.pc === undefined) {
+			Janus.warn("Invalid PeerConnection");
+			return false;
+		}
+		if(config.myStream === undefined || config.myStream === null) {
+			Janus.warn("Invalid local MediaStream");
+			return false;
+		}
+		if(video) {
+			// Mute/unmute video track
+			if(config.myStream.getVideoTracks() === null
+					|| config.myStream.getVideoTracks() === undefined
+					|| config.myStream.getVideoTracks().length === 0) {
+				Janus.warn("No video track");
+				return false;
+			}
+			config.myStream.getVideoTracks()[0].enabled = mute ? false : true;
+			return true;
+		} else {
+			// Mute/unmute audio track
+			if(config.myStream.getAudioTracks() === null
+					|| config.myStream.getAudioTracks() === undefined
+					|| config.myStream.getAudioTracks().length === 0) {
+				Janus.warn("No audio track");
+				return false;
+			}
+			config.myStream.getAudioTracks()[0].enabled = mute ? false : true;
+			return true;
+		}
+	}
+
+	function getBitrate(handleId) {
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined ||
+				pluginHandle.webrtcStuff === null || pluginHandle.webrtcStuff === undefined) {
+			Janus.warn("Invalid handle");
+			return "Invalid handle";
+		}
+		var config = pluginHandle.webrtcStuff;
+		if(config.pc === null || config.pc === undefined)
+			return "Invalid PeerConnection";
+		// Start getting the bitrate, if getStats is supported
+		if(config.pc.getStats) {
+			if(config.bitrate.timer === null || config.bitrate.timer === undefined) {
+				Janus.log("Starting bitrate timer (via getStats)");
+				config.bitrate.timer = setInterval(function() {
+					config.pc.getStats()
+						.then(function(stats) {
+							stats.forEach(function (res) {
+								if(!res)
+									return;
+								var inStats = false;
+								// Check if these are statistics on incoming media
+								if((res.mediaType === "video" || res.id.toLowerCase().indexOf("video") > -1) &&
+										res.type === "inbound-rtp" && res.id.indexOf("rtcp") < 0) {
+									// New stats
+									inStats = true;
+								} else if(res.type == 'ssrc' && res.bytesReceived &&
+										(res.googCodecName === "VP8" || res.googCodecName === "")) {
+									// Older Chromer versions
+									inStats = true;
+								}
+								// Parse stats now
+								if(inStats) {
+									config.bitrate.bsnow = res.bytesReceived;
+									config.bitrate.tsnow = res.timestamp;
+									if(config.bitrate.bsbefore === null || config.bitrate.tsbefore === null) {
+										// Skip this round
+										config.bitrate.bsbefore = config.bitrate.bsnow;
+										config.bitrate.tsbefore = config.bitrate.tsnow;
+									} else {
+										// Calculate bitrate
+										var timePassed = config.bitrate.tsnow - config.bitrate.tsbefore;
+										if(Janus.webRTCAdapter.browserDetails.browser == "safari")
+											timePassed = timePassed/1000;	// Apparently the timestamp is in microseconds, in Safari
+										var bitRate = Math.round((config.bitrate.bsnow - config.bitrate.bsbefore) * 8 / timePassed);
+										config.bitrate.value = bitRate + ' kbits/sec';
+										//~ Janus.log("Estimated bitrate is " + config.bitrate.value);
+										config.bitrate.bsbefore = config.bitrate.bsnow;
+										config.bitrate.tsbefore = config.bitrate.tsnow;
+									}
+								}
+							});
+						});
+				}, 1000);
+				return "0 kbits/sec";	// We don't have a bitrate value yet
+			}
+			return config.bitrate.value;
+		} else {
+			Janus.warn("Getting the video bitrate unsupported by browser");
+			return "Feature unsupported by browser";
+		}
+	}
+
+	function webrtcError(error) {
+		Janus.error("WebRTC error:", error);
+	}
+
+	function cleanupWebrtc(handleId, hangupRequest) {
+		Janus.log("Cleaning WebRTC stuff");
+		var pluginHandle = pluginHandles[handleId];
+		if(pluginHandle === null || pluginHandle === undefined) {
+			// Nothing to clean
+			return;
+		}
+		var config = pluginHandle.webrtcStuff;
+		if(config !== null && config !== undefined) {
+			if(hangupRequest === true) {
+				// Send a hangup request (we don't really care about the response)
+				var request = { "janus": "hangup", "transaction": Janus.randomString(12) };
+				if(pluginHandle.token !== null && pluginHandle.token !== undefined)
+					request["token"] = pluginHandle.token;
+				if(apisecret !== null && apisecret !== undefined)
+					request["apisecret"] = apisecret;
+				Janus.debug("Sending hangup request (handle=" + handleId + "):");
+				Janus.debug(request);
+				if(websockets) {
+					request["session_id"] = sessionId;
+					request["handle_id"] = handleId;
+					ws.send(JSON.stringify(request));
+				} else {
+					Janus.httpAPICall(server + "/" + sessionId + "/" + handleId, {
+						verb: 'POST',
+						withCredentials: withCredentials,
+						body: request
+					});
+				}
+			}
+			// Cleanup stack
+			config.remoteStream = null;
+			if(config.volume.timer)
+				clearInterval(config.volume.timer);
+			config.volume.value = null;
+			if(config.bitrate.timer)
+				clearInterval(config.bitrate.timer);
+			config.bitrate.timer = null;
+			config.bitrate.bsnow = null;
+			config.bitrate.bsbefore = null;
+			config.bitrate.tsnow = null;
+			config.bitrate.tsbefore = null;
+			config.bitrate.value = null;
+			try {
+				// Try a MediaStreamTrack.stop() for each track
+				if(!config.streamExternal && config.myStream !== null && config.myStream !== undefined) {
+					Janus.log("Stopping local stream tracks");
+					var tracks = config.myStream.getTracks();
+					for(var i in tracks) {
+						var mst = tracks[i];
+						Janus.log(mst);
+						if(mst !== null && mst !== undefined)
+							mst.stop();
+					}
+				}
+			} catch(e) {
+				// Do nothing if this fails
+			}
+			config.streamExternal = false;
+			config.myStream = null;
+			// Close PeerConnection
+			try {
+				config.pc.close();
+			} catch(e) {
+				// Do nothing
+			}
+			config.pc = null;
+			config.candidates = null;
+			config.mySdp = null;
+			config.remoteSdp = null;
+			config.iceDone = false;
+			config.dataChannel = null;
+			config.dtmfSender = null;
+		}
+		pluginHandle.oncleanup();
+	}
+
+	// Helper method to munge an SDP to enable simulcasting (Chrome only)
+	function mungeSdpForSimulcasting(sdp) {
+		// Let's munge the SDP to add the attributes for enabling simulcasting
+		// (based on https://gist.github.com/ggarber/a19b4c33510028b9c657)
+		var lines = sdp.split("\r\n");
+		var video = false;
+		var ssrc = [ -1 ], ssrc_fid = [ -1 ];
+		var cname = null, msid = null, mslabel = null, label = null;
+		var insertAt = -1;
+		for(var i=0; i<lines.length; i++) {
+			var mline = lines[i].match(/m=(\w+) */);
+			if(mline) {
+				var medium = mline[1];
+				if(medium === "video") {
+					// New video m-line: make sure it's the first one
+					if(ssrc[0] < 0) {
+						video = true;
+					} else {
+						// We're done, let's add the new attributes here
+						insertAt = i;
+						break;
+					}
+				} else {
+					// New non-video m-line: do we have what we were looking for?
+					if(ssrc[0] > -1) {
+						// We're done, let's add the new attributes here
+						insertAt = i;
+						break;
+					}
+				}
+				continue;
+			}
+			if(!video)
+				continue;
+			var fid = lines[i].match(/a=ssrc-group:FID (\d+) (\d+)/);
+			if(fid) {
+				ssrc[0] = fid[1];
+				ssrc_fid[0] = fid[2];
+				lines.splice(i, 1); i--;
+				continue;
+			}
+			if(ssrc[0]) {
+				var match = lines[i].match('a=ssrc:' + ssrc[0] + ' cname:(.+)')
+				if(match) {
+					cname = match[1];
+				}
+				match = lines[i].match('a=ssrc:' + ssrc[0] + ' msid:(.+)')
+				if(match) {
+					msid = match[1];
+				}
+				match = lines[i].match('a=ssrc:' + ssrc[0] + ' mslabel:(.+)')
+				if(match) {
+					mslabel = match[1];
+				}
+				match = lines[i].match('a=ssrc:' + ssrc + ' label:(.+)')
+				if(match) {
+					label = match[1];
+				}
+				if(lines[i].indexOf('a=ssrc:' + ssrc_fid) === 0) {
+					lines.splice(i, 1); i--;
+					continue;
+				}
+				if(lines[i].indexOf('a=ssrc:' + ssrc[0]) === 0) {
+					lines.splice(i, 1); i--;
+					continue;
+				}
+			}
+			if(lines[i].length == 0) {
+				lines.splice(i, 1); i--;
+				continue;
+			}
+		}
+		if(ssrc[0] < 0) {
+			// Couldn't find a FID attribute, let's just take the first video SSRC we find
+			insertAt = -1;
+			video = false;
+			for(var i=0; i<lines.length; i++) {
+				var mline = lines[i].match(/m=(\w+) */);
+				if(mline) {
+					var medium = mline[1];
+					if(medium === "video") {
+						// New video m-line: make sure it's the first one
+						if(ssrc[0] < 0) {
+							video = true;
+						} else {
+							// We're done, let's add the new attributes here
+							insertAt = i;
+							break;
+						}
+					} else {
+						// New non-video m-line: do we have what we were looking for?
+						if(ssrc[0] > -1) {
+							// We're done, let's add the new attributes here
+							insertAt = i;
+							break;
+						}
+					}
+					continue;
+				}
+				if(!video)
+					continue;
+				if(ssrc[0] < 0) {
+					var value = lines[i].match(/a=ssrc:(\d+)/);
+					if(value) {
+						ssrc[0] = value[1];
+						lines.splice(i, 1); i--;
+						continue;
+					}
+				} else {
+					var match = lines[i].match('a=ssrc:' + ssrc[0] + ' cname:(.+)')
+					if(match) {
+						cname = match[1];
+					}
+					match = lines[i].match('a=ssrc:' + ssrc[0] + ' msid:(.+)')
+					if(match) {
+						msid = match[1];
+					}
+					match = lines[i].match('a=ssrc:' + ssrc[0] + ' mslabel:(.+)')
+					if(match) {
+						mslabel = match[1];
+					}
+					match = lines[i].match('a=ssrc:' + ssrc[0] + ' label:(.+)')
+					if(match) {
+						label = match[1];
+					}
+					if(lines[i].indexOf('a=ssrc:' + ssrc_fid[0]) === 0) {
+						lines.splice(i, 1); i--;
+						continue;
+					}
+					if(lines[i].indexOf('a=ssrc:' + ssrc[0]) === 0) {
+						lines.splice(i, 1); i--;
+						continue;
+					}
+				}
+				if(lines[i].length == 0) {
+					lines.splice(i, 1); i--;
+					continue;
+				}
+			}
+		}
+		if(ssrc[0] < 0) {
+			// Still nothing, let's just return the SDP we were asked to munge
+			Janus.warn("Couldn't find the video SSRC, simulcasting NOT enabled");
+			return sdp;
+		}
+		if(insertAt < 0) {
+			// Append at the end
+			insertAt = lines.length;
+		}
+		// Generate a couple of SSRCs (for retransmissions too)
+		// Note: should we check if there are conflicts, here?
+		ssrc[1] = Math.floor(Math.random()*0xFFFFFFFF);
+		ssrc[2] = Math.floor(Math.random()*0xFFFFFFFF);
+		ssrc_fid[1] = Math.floor(Math.random()*0xFFFFFFFF);
+		ssrc_fid[2] = Math.floor(Math.random()*0xFFFFFFFF);
+		// Add attributes to the SDP
+		for(var i=0; i<ssrc.length; i++) {
+			if(cname) {
+				lines.splice(insertAt, 0, 'a=ssrc:' + ssrc[i] + ' cname:' + cname);
+				insertAt++;
+			}
+			if(msid) {
+				lines.splice(insertAt, 0, 'a=ssrc:' + ssrc[i] + ' msid:' + msid);
+				insertAt++;
+			}
+			if(mslabel) {
+				lines.splice(insertAt, 0, 'a=ssrc:' + ssrc[i] + ' mslabel:' + mslabel);
+				insertAt++;
+			}
+			if(label) {
+				lines.splice(insertAt, 0, 'a=ssrc:' + ssrc[i] + ' label:' + label);
+				insertAt++;
+			}
+			// Add the same info for the retransmission SSRC
+			if(cname) {
+				lines.splice(insertAt, 0, 'a=ssrc:' + ssrc_fid[i] + ' cname:' + cname);
+				insertAt++;
+			}
+			if(msid) {
+				lines.splice(insertAt, 0, 'a=ssrc:' + ssrc_fid[i] + ' msid:' + msid);
+				insertAt++;
+			}
+			if(mslabel) {
+				lines.splice(insertAt, 0, 'a=ssrc:' + ssrc_fid[i] + ' mslabel:' + mslabel);
+				insertAt++;
+			}
+			if(label) {
+				lines.splice(insertAt, 0, 'a=ssrc:' + ssrc_fid[i] + ' label:' + label);
+				insertAt++;
+			}
+		}
+		lines.splice(insertAt, 0, 'a=ssrc-group:FID ' + ssrc[2] + ' ' + ssrc_fid[2]);
+		lines.splice(insertAt, 0, 'a=ssrc-group:FID ' + ssrc[1] + ' ' + ssrc_fid[1]);
+		lines.splice(insertAt, 0, 'a=ssrc-group:FID ' + ssrc[0] + ' ' + ssrc_fid[0]);
+		lines.splice(insertAt, 0, 'a=ssrc-group:SIM ' + ssrc[0] + ' ' + ssrc[1] + ' ' + ssrc[2]);
+		sdp = lines.join("\r\n");
+		if(!sdp.endsWith("\r\n"))
+			sdp += "\r\n";
+		return sdp;
+	}
+
+	// Helper methods to parse a media object
+	function isAudioSendEnabled(media) {
+		Janus.debug("isAudioSendEnabled:", media);
+		if(media === undefined || media === null)
+			return true;	// Default
+		if(media.audio === false)
+			return false;	// Generic audio has precedence
+		if(media.audioSend === undefined || media.audioSend === null)
+			return true;	// Default
+		return (media.audioSend === true);
+	}
+
+	function isAudioSendRequired(media) {
+		Janus.debug("isAudioSendRequired:", media);
+		if(media === undefined || media === null)
+			return false;	// Default
+		if(media.audio === false || media.audioSend === false)
+			return false;	// If we're not asking to capture audio, it's not required
+		if(media.failIfNoAudio === undefined || media.failIfNoAudio === null)
+			return false;	// Default
+		return (media.failIfNoAudio === true);
+	}
+
+	function isAudioRecvEnabled(media) {
+		Janus.debug("isAudioRecvEnabled:", media);
+		if(media === undefined || media === null)
+			return true;	// Default
+		if(media.audio === false)
+			return false;	// Generic audio has precedence
+		if(media.audioRecv === undefined || media.audioRecv === null)
+			return true;	// Default
+		return (media.audioRecv === true);
+	}
+
+	function isVideoSendEnabled(media) {
+		Janus.debug("isVideoSendEnabled:", media);
+		if(media === undefined || media === null)
+			return true;	// Default
+		if(media.video === false)
+			return false;	// Generic video has precedence
+		if(media.videoSend === undefined || media.videoSend === null)
+			return true;	// Default
+		return (media.videoSend === true);
+	}
+
+	function isVideoSendRequired(media) {
+		Janus.debug("isVideoSendRequired:", media);
+		if(media === undefined || media === null)
+			return false;	// Default
+		if(media.video === false || media.videoSend === false)
+			return false;	// If we're not asking to capture video, it's not required
+		if(media.failIfNoVideo === undefined || media.failIfNoVideo === null)
+			return false;	// Default
+		return (media.failIfNoVideo === true);
+	}
+
+	function isVideoRecvEnabled(media) {
+		Janus.debug("isVideoRecvEnabled:", media);
+		if(media === undefined || media === null)
+			return true;	// Default
+		if(media.video === false)
+			return false;	// Generic video has precedence
+		if(media.videoRecv === undefined || media.videoRecv === null)
+			return true;	// Default
+		return (media.videoRecv === true);
+	}
+
+	function isDataEnabled(media) {
+		Janus.debug("isDataEnabled:", media);
+		if(Janus.webRTCAdapter.browserDetails.browser == "edge") {
+			Janus.warn("Edge doesn't support data channels yet");
+			return false;
+		}
+		if(media === undefined || media === null)
+			return false;	// Default
+		return (media.data === true);
+	}
+
+	function isTrickleEnabled(trickle) {
+		Janus.debug("isTrickleEnabled:", trickle);
+		if(trickle === undefined || trickle === null)
+			return true;	// Default is true
+		return (trickle === true);
+	}
+};
+
+export default Janus;

--- a/client/src/hooks/useFleetData.tsx
+++ b/client/src/hooks/useFleetData.tsx
@@ -15,7 +15,7 @@ export function useFleetData() {
 
     useEffect(() => {
         // Fetch fleet data every 5 seconds
-        const interval = setInterval(fetchFleetData, 5000);
+        const interval = setInterval(fetchFleetData, 2000);
         
         fetchFleetData();
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -21,6 +21,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/components/VideoStream/index.jsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Added image capture capabilities. To enable this you must start the video streaming server. Run `docker compose up` in `/camera-stream/`. This will attach to the specified camera and start streaming it to the client. You can view the stream by clicking watch in the ember details page: `http://localhost:3000/embr-details`. 

The main page now splits to show the ember details page when you click on a fleet. 