### PR TITLE
added mission name to details tab

### DIFF
--- a/client/src/components/Details/MissionPanel.tsx
+++ b/client/src/components/Details/MissionPanel.tsx
@@ -85,7 +85,7 @@ function MissionPanel({ activeBot, activeMission }: { activeBot: RobotType, acti
                 <span
                     className={`w-full py-3 text-center text-sm font-semibold transition-colors duration-200 bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800"}`}
                 >
-                General Information
+                General Information for {activeMission.missionName}
                 </span>
             </div>
             <InfoGrid data={areaData}/>


### PR DESCRIPTION
## Summary
---
I just added the mission name input by the client to the details tab for the bot to specify the mission.

## Related Task
(https://www.notion.so/Add-Mission-name-to-Mission-tab-on-bot-info-side-bar-29405a18706d8060a571f4cd98b4f1d1?source=copy_link)

---

## Type of Change
Select all that apply:

- [x] 🆕 Feature  

---

## 📄 Documentation
- [ ] All of the following applicable documentation changes were added
  - [ ] How to connect the new device and wiring
  - [ ] Links to external documentation on the device
  - [ ] Any other setup or important information
- [x] No documentation changes required  

---

## 🧪 Testing
I rebuild the container with the new client code and saw the mission name in the details tab. 
<img width="636" height="906" alt="image" src="https://github.com/user-attachments/assets/bf2a7ca0-d327-4ae8-b277-e480bcd720c9" />

---

## ✅ Pre-Merge Checklist

* [x] PR started as a **Draft**
* [x] Linked to correct **Notion Task**
* [x] Branch includes updated documentation
* [ ] Code reviewed by peer
* [ ] Ready for final review by Software Lead
* [x] All tests and builds pass
* [ ] Notion task updated to **Ready for Review**

---
