### PR TITLE
Feature add mission name overlay on red mission box

### DIFF
--- a/client/src/utils/MapDrawUtils.tsx
+++ b/client/src/utils/MapDrawUtils.tsx
@@ -64,13 +64,12 @@ export default class MapDrawUtils {
       fillOpacity: 0.35,
     });
 
-    // Add mission name on top right of rectangle
+    // Add mission name on top mid of rectangle
     const labelPosition = {
       lat: bounds.north - 0.0005,
       lng: (bounds.west + bounds.east)/2,
     };
 
-    //Text for the label
     const labelMarker = new google.maps.Marker({
       position: labelPosition,
       map: map,

--- a/client/src/utils/MapDrawUtils.tsx
+++ b/client/src/utils/MapDrawUtils.tsx
@@ -64,6 +64,27 @@ export default class MapDrawUtils {
       fillOpacity: 0.35,
     });
 
+    // Add mission name on top right of rectangle
+    const labelPosition = {
+      lat: bounds.north - 0.0005,
+      lng: (bounds.west + bounds.east)/2,
+    };
+
+    //Text for the label
+    const labelMarker = new google.maps.Marker({
+      position: labelPosition,
+      map: map,
+      icon: { path: google.maps.SymbolPath.CIRCLE, scale: 0 }, // invisible icon
+      label: {
+        text: mission.missionName || "Unnamed Mission",
+        color: "black",
+        fontSize: "14px",
+        fontWeight: "bold",
+      }
+    });
+
+    
+
     this.missionAreas.push(rectangle);
   }
 


### PR DESCRIPTION
## Summary
Provide a short, clear description of what this PR does and why.

Change MapDrawUtils.tsx to display the mission name on the red mission box


## Related Task
[Closes [Notion Task](PASTE_NOTION_TASK_LINK_HERE)](https://www.notion.so/Add-mission-name-overlay-on-red-mission-rectangle-29405a18706d8056ac8eef97f5e453a1?v=29405a18706d8056ac8eef97f5e453a1&pvs=26)

---

## Type of Change
Select all that apply:

- [x] 🆕 Feature  
- [ ] 🐞 Bug Fix  
- [ ] 🧹 Refactor  
- [ ] 🧾 Documentation Update  
- [ ] 🧰 Maintenance / Tooling  
- [ ] Other (specify below)

---

## 📄 Documentation
- [ ] All of the following applicable documentation changes were added
  - [ ] How to connect the new device and wiring
  - [ ] Links to external documentation on the device
  - [ ] Any other setup or important information
- [x] No documentation changes required  

---

## 🧪 Testing
Describe how this change was tested.  
Include commands or steps used, and confirm successful results.

---

## Image of GUI change (if applicable)
<img width="720" height="328" alt="image" src="https://github.com/user-attachments/assets/65df792e-d67e-4b11-84fa-5b250c93d99f" />

---

## ✅ Pre-Merge Checklist

* [x] PR started as a **Draft**
* [ ] Linked to correct **Notion Task**
* [ ] Branch includes updated documentation
* [ ] Code reviewed by peer
* [ ] Ready for final review by Software Lead
* [ ] All tests and builds pass
* [ ] Notion task updated to **Ready for Review**

---

## 🧾 Notes (Optional)

Add any context, screenshots, or known issues reviewers should know about.
