### PR TITLE
Change the mission name overlay to be on top of the red mission rectangle

### DIFF
--- a/client/src/utils/MapDrawUtils.tsx
+++ b/client/src/utils/MapDrawUtils.tsx
@@ -64,6 +64,24 @@ export default class MapDrawUtils {
       fillOpacity: 0.35,
     });
 
+    const labelPosition = {
+      lat: bounds.north - 0.0005,
+      lng: (bounds.west + bounds.east)/2,
+    };
+
+    //Text for the label
+    const labelMarker = new google.maps.Marker({
+      position: labelPosition,
+      map: map,
+      icon: { path: google.maps.SymbolPath.CIRCLE, scale: 0 }, // invisible icon
+      label: {
+        text: mission.missionName || "Unnamed Mission",
+        color: "black",
+        fontSize: "14px",
+        fontWeight: "bold",
+      }
+    });
+
     this.missionAreas.push(rectangle);
   }
 


### PR DESCRIPTION
…ngle

## Summary
Updates MapDrawUtils.tsx to also render the name of the mission on top of the red mission box
---

## Related Task
Closes https://www.notion.so/Add-mission-name-overlay-on-red-mission-rectangle-29405a18706d8056ac8eef97f5e453a1?source=copy_link


---

## Type of Change
Select all that apply:

- [x] 🆕 Feature  
- [ ] 🐞 Bug Fix  
- [ ] 🧹 Refactor  
- [ ] 🧾 Documentation Update  
- [ ] 🧰 Maintenance / Tooling  
- [ ] Other (specify below)

---

## 📄 Documentation
- [ ] All of the following applicable documentation changes were added
  - [ ] How to connect the new device and wiring
  - [ ] Links to external documentation on the device
  - [ ] Any other setup or important information
- [ ] No documentation changes required  

---

## 🧪 Testing
Describe how this change was tested.  
Include commands or steps used, and confirm successful results.

---

## Image of GUI change (if applicable)
<img width="1913" height="853" alt="image" src="https://github.com/user-attachments/assets/70849923-b6fe-4fcc-8425-c2e78f75677b" />


---

## ✅ Pre-Merge Checklist

* [ ] PR started as a **Draft**
* [ ] Linked to correct **Notion Task**
* [ ] Branch includes updated documentation
* [ ] Code reviewed by peer
* [ ] Ready for final review by Software Lead
* [ ] All tests and builds pass
* [ ] Notion task updated to **Ready for Review**

---

## 🧾 Notes (Optional)

Add any context, screenshots, or known issues reviewers should know about.
