### PR TITLE
Feature mission outline opens mission details page

### DIFF
--- a/client/src/components/features/dashboard/DashboardSidebar.tsx
+++ b/client/src/components/features/dashboard/DashboardSidebar.tsx
@@ -43,7 +43,7 @@ export default function DashboardSidebar({
 
   return (
     <div
-      className={`bg-white border-l border-gray-200 flex flex-col transition-all duration-300 overflow-hidden ${
+      className={`bg-white border-l border-gray-200 flex flex-col transition-all duration-300 overflow-hidden mb-16 ${
         isCollapsed ? 'w-16' : 'w-96'
       }`}
     >

--- a/client/src/components/features/map/GoogleMap.tsx
+++ b/client/src/components/features/map/GoogleMap.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useJsApiLoader, GoogleMap } from '@react-google-maps/api';
+import { useJsApiLoader, GoogleMap, OverlayViewF, OverlayView } from '@react-google-maps/api';
 import { Map, Satellite } from 'lucide-react';
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import {
   createRectangle,
@@ -18,6 +18,7 @@ import {
 import Search from '@/components/features/map/MapTools/search';
 import { MissionType, RobotType } from '@/types';
 import { CoordinatesType } from '@/types/coordinate.type';
+import { useRouter } from 'next/navigation';
 
 // ========== COMPONENT ==========
 
@@ -40,11 +41,11 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
   onRectangleSet,
   showSearch = true,
 }) => {
-  // Map State
   const [map, setMap] = useState<google.maps.Map | null>(null);
   const [satelliteView, setSatelliteView] = useState<boolean>(false);
   const [hasInitialized, setHasInitialized] = useState<boolean>(false);
   const [editableRectangle, setEditableRectangle] = useState<google.maps.Rectangle | null>(null);
+  const router = useRouter();
 
   const { isLoaded, loadError } = useJsApiLoader({
     id: 'google-map-script',
@@ -54,29 +55,23 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
 
   const mapOptions = isLoaded ? getMapOptions(satelliteView) : {};
 
-  // ========== MAP CALLBACKS ==========
-
   const onLoad = useCallback(function callback(map: google.maps.Map | null) {
-    if (map) {
-      setMap(map);
-    }
+    if (map) setMap(map);
   }, []);
 
   const onUnmount = useCallback(function callback() {
     setMap(null);
   }, []);
 
-  // Handle map clicks to create rectangle when drawing mode is active and no rectangle exists
+  // Handle drawing mode logic
   useEffect(() => {
     if (!map || !drawingMode) return;
 
     const clickListener = map.addListener('click', (e: google.maps.MapMouseEvent) => {
       if (!currentRectangle && e.latLng && onRectangleChange) {
-        // Create a small rectangle at the clicked location
         const clickedLat = e.latLng.lat();
         const clickedLng = e.latLng.lng();
-        const offset = 0.001; // Small default size
-
+        const offset = 0.001;
         onRectangleChange(
           { lat: clickedLat + offset, lng: clickedLng - offset },
           { lat: clickedLat - offset, lng: clickedLng + offset },
@@ -84,16 +79,12 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
       }
     });
 
-    return () => {
-      google.maps.event.removeListener(clickListener);
-    };
+    return () => google.maps.event.removeListener(clickListener);
   }, [map, drawingMode, currentRectangle, onRectangleChange]);
 
-  // Create or update the editable rectangle
   useEffect(() => {
     if (!map || !drawingMode) return;
 
-    // If no current rectangle, remove the editable one
     if (!currentRectangle) {
       removeRectangle(editableRectangle);
       setEditableRectangle(null);
@@ -104,20 +95,14 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
     const bounds = coordinatesToBounds(currentRectangle.northWest, currentRectangle.southEast);
 
     if (editableRectangle) {
-      // Update existing rectangle bounds when coordinates change manually
       updateRectangleBounds(editableRectangle, bounds);
     } else {
-      // Create new editable rectangle
-      const rectangle = createRectangle(bounds, map, (northWest, southEast) => {
-        onRectangleChange?.(northWest, southEast);
-      });
-
+      const rectangle = createRectangle(bounds, map, (nw, se) => onRectangleChange?.(nw, se));
       setEditableRectangle(rectangle);
       onRectangleSet?.(rectangle);
     }
   }, [map, drawingMode, currentRectangle, onRectangleChange, onRectangleSet, editableRectangle]);
 
-  // Clean up rectangle when drawing mode is disabled
   useEffect(() => {
     if (!drawingMode && editableRectangle) {
       removeRectangle(editableRectangle);
@@ -126,54 +111,32 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
     }
   }, [drawingMode, editableRectangle, onRectangleSet]);
 
-  // ========== EFFECTS ==========
-
-  // Initialize map view based on bots and missions
   useEffect(() => {
     if (!map || hasInitialized) return;
-
-    const hasBots = bots && bots.length > 0;
-    const hasMissions = missionsData && missionsData.length > 0;
-
-    if (!hasBots && !hasMissions) {
-      // No data yet - wait for it to load
-      return;
-    }
+    if ((!bots || bots.length === 0) && (!missionsData || missionsData.length === 0)) return;
 
     initializeMapView(map, bots, missionsData);
-
     setHasInitialized(true);
   }, [map, bots, missionsData, hasInitialized]);
 
-  // Update bot markers on map
   useEffect(() => {
     if (!map || !bots || bots.length === 0) return;
     drawBots(bots, map);
   }, [bots, map]);
 
-  // Update mission areas on map (exclude editable one)
   useEffect(() => {
     if (!map || !missionsData || missionsData.length === 0) return;
-    drawMissionAreas(missionsData, map);
+    drawMissionAreas(missionsData, map); // Only drawing rectangle/dot here
   }, [missionsData, map]);
 
-  // Update map type when satelliteView changes
   useEffect(() => {
     if (!map) return;
     map.setMapTypeId(satelliteView ? 'satellite' : 'roadmap');
   }, [satelliteView, map]);
 
-  // ========== LOADING STATE ==========
+  if (loadError) return <div className="flex items-center justify-center h-full">Error loading maps</div>;
+  if (!isLoaded) return <div className="flex items-center justify-center h-full">Loading maps...</div>;
 
-  if (loadError) {
-    return <div className="flex items-center justify-center h-full">Error loading maps</div>;
-  }
-
-  if (!isLoaded) {
-    return <div className="flex items-center justify-center h-full">Loading maps...</div>;
-  }
-
-  // ========== RENDER ==========
   return (
     <div className="h-full w-full relative">
       <GoogleMap
@@ -181,10 +144,43 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
         mapContainerClassName="h-full w-full"
         onLoad={onLoad}
         onUnmount={onUnmount}
-      />
+      >
+        {/* Overlay for Clickable Mission Names */}
+        {missionsData?.map((mission) => {
+          if (!mission.areaCoordinates) return null;
+
+          const position = {
+            lat: mission.areaCoordinates[0].lat,
+            lng: (mission.areaCoordinates[0].lng + mission.areaCoordinates[1].lng) / 2,
+          };
+
+          return (
+            <OverlayViewF
+              key={mission.missionID}
+              position={position}
+              mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
+            >
+              <div
+                style={{ transform: 'translate(-50%, -180%)', whiteSpace: 'nowrap' }}
+                className="z-50"
+              >
+                <span
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    router.push(`/missions/${mission.missionID}`);
+                  }}
+                  className="cursor-pointer font-bold text-sm text-black bg-white/90 px-2 py-0.5 rounded shadow-md border border-gray-200 hover:text-blue-600 hover:underline transition-all"
+                >
+                  {mission.missionName || 'Unnamed Mission'}
+                </span>
+              </div>
+            </OverlayViewF>
+          );
+        })}
+      </GoogleMap>
 
       {/* Search Box */}
-      {showSearch && isLoaded && (
+      {showSearch && (
         <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-10">
           <Search />
         </div>
@@ -195,17 +191,14 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
         <button
           onClick={() => setSatelliteView(!satelliteView)}
           className="px-4 py-2 bg-white rounded-md shadow hover:bg-gray-100 flex items-center gap-2 transition-colors"
-          aria-label={satelliteView ? 'Switch to map view' : 'Switch to satellite view'}
         >
           {satelliteView ? (
             <>
-              <Map size={18} />
-              <span>Map</span>
+              <Map size={18} /> <span>Map</span>
             </>
           ) : (
             <>
-              <Satellite size={18} />
-              <span>Satellite</span>
+              <Satellite size={18} /> <span>Satellite</span>
             </>
           )}
         </button>
@@ -214,7 +207,7 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
       {/* Drawing Mode Indicator */}
       {drawingMode && (
         <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-10">
-          <div className="bg-blue-600 text-white px-4 py-2 rounded-md shadow-lg">
+          <div className="bg-blue-600 text-white px-4 py-2 rounded-md shadow-lg text-center">
             {currentRectangle
               ? '🖊️ Drawing Mode Active - Drag corners/edges to adjust area'
               : '📍 Click anywhere on the map to create a new area'}

--- a/client/src/components/features/map/GoogleMap.tsx
+++ b/client/src/components/features/map/GoogleMap.tsx
@@ -126,7 +126,7 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
 
   useEffect(() => {
     if (!map || !missionsData || missionsData.length === 0) return;
-    drawMissionAreas(missionsData, map); // Only drawing rectangle/dot here
+    drawMissionAreas(missionsData, map); // Only drawing rectangle areas, not clickable names, which are handled in the main component render
   }, [missionsData, map]);
 
   useEffect(() => {
@@ -191,6 +191,7 @@ const CustomGoogleMap: React.FC<CustomGoogleMapProps> = ({
         <button
           onClick={() => setSatelliteView(!satelliteView)}
           className="px-4 py-2 bg-white rounded-md shadow hover:bg-gray-100 flex items-center gap-2 transition-colors"
+        aria-label={satelliteView ? 'Switch to map view' : 'Switch to satellite view'}
         >
           {satelliteView ? (
             <>

--- a/client/src/components/features/map/MapTools/MapDrawUtils.tsx
+++ b/client/src/components/features/map/MapTools/MapDrawUtils.tsx
@@ -3,6 +3,9 @@ import { Marker } from '@react-google-maps/api';
 import { RobotOperationalStatusType } from '@/constants/robotConstants';
 import { MissionType } from '@/types/mission.type';
 import { RobotType } from '@/types/robot.type';
+import type { useRouter } from 'next/navigation';
+
+type AppRouter = ReturnType<typeof useRouter>;
 
 class MapDrawUtilsClass {
   static markers: google.maps.Marker[] = [];
@@ -14,10 +17,10 @@ class MapDrawUtilsClass {
     robots.forEach((robot: RobotType) => this.drawBot(robot, map));
   }
 
-  static drawMissionAreas(missions: MissionType[], map: google.maps.Map) {
+  static drawMissionAreas(missions: MissionType[], map: google.maps.Map,  router?: AppRouter) {
     this.removeOldMissionAreas();
     // Draw each mission area in the list
-    missions.forEach((mission) => this.drawMissionArea(mission, map));
+    missions.forEach((mission) => this.drawMissionArea(mission, map, router));
   }
 
   private static drawBot(robot: RobotType, map: google.maps.Map) {
@@ -43,7 +46,7 @@ class MapDrawUtilsClass {
     this.markers.push(marker);
   }
 
-  private static drawMissionArea(mission: MissionType, map: google.maps.Map) {
+  private static drawMissionArea(mission: MissionType, map: google.maps.Map, router? : ReturnType <typeof useRouter>) {
     if (!mission.areaCoordinates) return;
 
     //console.log(mission.areaCoordinates);
@@ -63,9 +66,10 @@ class MapDrawUtilsClass {
       strokeWeight: 2,
       fillColor: mission.timeEnd ? '#00FF00' : mission.timeStart ? '#FFFF00' : '#686363',
       fillOpacity: 0.35,
+      clickable: false,
     });
 
-    const labelPosition = {
+    /*const labelPosition = {
       lat: bounds.north - 0.0005,
       lng: (bounds.west + bounds.east) / 2,
     };
@@ -74,6 +78,8 @@ class MapDrawUtilsClass {
     const labelMarker = new google.maps.Marker({
       position: labelPosition,
       map: map,
+      clickable: true,
+      cursor: 'pointer',
       icon: { path: google.maps.SymbolPath.CIRCLE, scale: 0 }, // invisible icon
       label: {
         text: mission.missionName || 'Unnamed Mission',
@@ -83,6 +89,13 @@ class MapDrawUtilsClass {
       },
     });
 
+    // Added click listener to label to navigate to mission details page
+    // This is like a bridge between the google maps api and nextjs router
+    if(router){
+      labelMarker.addListener('click', () =>{
+        router.push(`/missions/${mission.missionID}`)
+      });
+    }*/
     this.missionAreas.push(rectangle);
   }
 

--- a/client/src/components/features/map/MapTools/MapDrawUtils.tsx
+++ b/client/src/components/features/map/MapTools/MapDrawUtils.tsx
@@ -3,10 +3,8 @@ import { Marker } from '@react-google-maps/api';
 import { RobotOperationalStatusType } from '@/constants/robotConstants';
 import { MissionType } from '@/types/mission.type';
 import { RobotType } from '@/types/robot.type';
-import type { useRouter } from 'next/navigation';
 
-type AppRouter = ReturnType<typeof useRouter>;
-//better to use this type of router for tsx files
+
 class MapDrawUtilsClass {
   static markers: google.maps.Marker[] = [];
   static missionAreas: google.maps.Rectangle[] = [];
@@ -17,10 +15,10 @@ class MapDrawUtilsClass {
     robots.forEach((robot: RobotType) => this.drawBot(robot, map));
   }
 
-  static drawMissionAreas(missions: MissionType[], map: google.maps.Map,  router?: AppRouter) {
+  static drawMissionAreas(missions: MissionType[], map: google.maps.Map) {
     this.removeOldMissionAreas();
     // Draw each mission area in the list
-    missions.forEach((mission) => this.drawMissionArea(mission, map, router));
+    missions.forEach((mission) => this.drawMissionArea(mission, map));
   }
 
   private static drawBot(robot: RobotType, map: google.maps.Map) {
@@ -46,7 +44,7 @@ class MapDrawUtilsClass {
     this.markers.push(marker);
   }
 
-  private static drawMissionArea(mission: MissionType, map: google.maps.Map, router? : ReturnType <typeof useRouter>) {
+  private static drawMissionArea(mission: MissionType, map: google.maps.Map) {
     if (!mission.areaCoordinates) return;
 
     //console.log(mission.areaCoordinates);

--- a/client/src/components/features/map/MapTools/MapDrawUtils.tsx
+++ b/client/src/components/features/map/MapTools/MapDrawUtils.tsx
@@ -69,33 +69,6 @@ class MapDrawUtilsClass {
       clickable: false,
     });
 
-    /*const labelPosition = {
-      lat: bounds.north - 0.0005,
-      lng: (bounds.west + bounds.east) / 2,
-    };
-
-    //Text for the label
-    const labelMarker = new google.maps.Marker({
-      position: labelPosition,
-      map: map,
-      clickable: true,
-      cursor: 'pointer',
-      icon: { path: google.maps.SymbolPath.CIRCLE, scale: 0 }, // invisible icon
-      label: {
-        text: mission.missionName || 'Unnamed Mission',
-        color: 'black',
-        fontSize: '14px',
-        fontWeight: 'bold',
-      },
-    });
-
-    // Added click listener to label to navigate to mission details page
-    // This is like a bridge between the google maps api and nextjs router
-    if(router){
-      labelMarker.addListener('click', () =>{
-        router.push(`/missions/${mission.missionID}`)
-      });
-    }*/
     this.missionAreas.push(rectangle);
   }
 

--- a/client/src/components/features/map/MapTools/MapDrawUtils.tsx
+++ b/client/src/components/features/map/MapTools/MapDrawUtils.tsx
@@ -61,10 +61,10 @@ class MapDrawUtilsClass {
     const rectangle = new google.maps.Rectangle({
       bounds,
       map,
-      strokeColor: mission.timeEnd ? '#00FF00' : mission.timeStart ? '#FFFF00' : '#686363',
+      strokeColor: mission.timeEnd ? '#00FF00' : mission.timeStart ? '#FFFF00' : '#262626',
       strokeOpacity: 0.8,
       strokeWeight: 2,
-      fillColor: mission.timeEnd ? '#00FF00' : mission.timeStart ? '#FFFF00' : '#686363',
+      fillColor: mission.timeEnd ? '#00FF00' : mission.timeStart ? '#FFFF00' : '#262626',
       fillOpacity: 0.35,
       clickable: false,
     });

--- a/client/src/components/features/map/MapTools/MapDrawUtils.tsx
+++ b/client/src/components/features/map/MapTools/MapDrawUtils.tsx
@@ -6,7 +6,7 @@ import { RobotType } from '@/types/robot.type';
 import type { useRouter } from 'next/navigation';
 
 type AppRouter = ReturnType<typeof useRouter>;
-
+//better to use this type of router for tsx files
 class MapDrawUtilsClass {
   static markers: google.maps.Marker[] = [];
   static missionAreas: google.maps.Rectangle[] = [];


### PR DESCRIPTION
## Summary
I added a clickable mission name on the Google Maps which redirects to the mission details and deleted the previous mission label. The rectangle for the not started mission is also darkened to make it more visible.
---

## Related Task
[Closes [Notion Task]
(https://www.notion.so/Click-on-mission-outline-opens-mission-details-page-2a705a18706d80518784eb8e3733dfea?source=copy_link)
---

## Type of Change
Select all that apply:

- [x] 🆕 Feature  
- [ ] 🐞 Bug Fix  
- [ ] 🧹 Refactor  
- [ ] 🧾 Documentation Update  
- [ ] 🧰 Maintenance / Tooling  
- [ ] Other (specify below)

---

## 📄 Documentation
- [ ] All of the following applicable documentation changes were added
  - [ ] How to connect the new device and wiring
  - [ ] Links to external documentation on the device
  - [ ] Any other setup or important information
- [ ] No documentation changes required  

---

## 🧪 Testing
Describe how this change was tested.  
Include commands or steps used, and confirm successful results.

---

## Image of GUI change (if applicable)
Paste an image of the GUI change.
<img width="1896" height="905" alt="image" src="https://github.com/user-attachments/assets/30d8b631-d329-49b0-a59f-8c35e6381786" />

---

## ✅ Pre-Merge Checklist

* [ ] PR started as a **Draft**
* [ ] Linked to correct **Notion Task**
* [ ] Branch includes updated documentation
* [ ] Code reviewed by peer
* [ ] Ready for final review by Software Lead
* [ ] All tests and builds pass
* [ ] Notion task updated to **Ready for Review**

---

## 🧾 Notes (Optional)

Add any context, screenshots, or known issues reviewers should know about.
