### PR TITLE
Feature sendmission

### DIFF
--- a/client/src/api/missions.api.ts
+++ b/client/src/api/missions.api.ts
@@ -126,7 +126,7 @@ export const startMission = async (id: number, time: string) => {
       headers: { 'Content-Type': 'application/json' },
     },
   );
-  return response.data as { message: string };
+  return response;
 };
 
 export const endMission = async (id: number, time: string) => {

--- a/client/src/app/missions/[id]/page.tsx
+++ b/client/src/app/missions/[id]/page.tsx
@@ -26,6 +26,22 @@ export default function MissionDetail() {
     console.log('Updating mission:', id);
 
     if (start) {
+
+      try {
+        // Push update to the database
+        const response = start 
+            ? await startMission(missionId, time) 
+            : await endMission(missionId, time);
+
+      if (response.status == 200) {
+          console.log("mission " + missionId + " sent: " + response.data.message);
+      }
+
+    } catch (error) {
+      alert(`Mission failed to start: ${error.response?.data?.error || error.message}`);
+      return;
+    }
+
       mission!.timeStart = time;
     } else if (!start) {
       mission!.timeEnd = time;
@@ -49,9 +65,6 @@ export default function MissionDetail() {
     }
     setMission(mission!);
 
-    // Push update to the database
-    const response = await (start ? startMission(missionId, time) : endMission(missionId, time));
-    console.log(`Mission ${start ? 'started' : 'ended'}:`, response);
   };
 
   const handleDelete = async (missionId: number, missionName: string) => {

--- a/client/src/app/missions/[id]/page.tsx
+++ b/client/src/app/missions/[id]/page.tsx
@@ -23,15 +23,13 @@ export default function MissionDetail() {
   const assignedBot = bots.find((b) => mission?.assignedBots?.includes(b.id));
 
   const handleStartEndMission = async (id: number, start: boolean, time: string) => {
-    console.log('Updating mission:', id);
+    console.log('Updating mission__:', id);
 
     if (start) {
 
       try {
         // Push update to the database
-        const response = start 
-            ? await startMission(missionId, time) 
-            : await endMission(missionId, time);
+        const response = await startMission(missionId, time);
 
       if (response.status == 200) {
           console.log("mission " + missionId + " sent: " + response.data.message);
@@ -44,6 +42,13 @@ export default function MissionDetail() {
 
       mission!.timeStart = time;
     } else if (!start) {
+      try {
+        const response = await endMission(missionId, time);
+      } catch(error) {
+        alert(`Mission failed to end: ${error.response?.data?.error || error.message}`);
+        return;
+      }
+      
       mission!.timeEnd = time;
     }
 

--- a/server/README.md
+++ b/server/README.md
@@ -196,3 +196,85 @@ The server can handle both real and simulated MAVLink data:
 - Develop hotspot functionality
 - Send mission area, temp threshold, # of temp readings per hotspot to bot on mission start
 
+
+## **`Connection Bridge from Windows to Linux`**
+To get your RFD900X radio working inside WSL (Ubuntu 22.04), you need to "bridge" the USB connection from Windows to Linux. Windows owns the hardware by default, so `usbipd` acts as the middleman.
+
+### 1. Install usbipd-win on Windows
+
+First, ensure you have the software installed on your **Windows host** (not inside WSL).
+
+1. Download the latest `.msi` installer from the [usbipd-win GitHub releases](https://github.com/dorssel/usbipd-win/releases).
+2. Run the installer.
+3. Open a **PowerShell** or **Command Prompt** with **Administrator privileges**.
+
+---
+
+### 2. Identify and Bind the Radio
+
+You need to tell Windows that it's okay to let WSL "borrow" this specific USB device.
+
+1. **List all USB devices:**
+```powershell
+usbipd list
+
+```
+
+
+Look for a device named something like "Silicon Labs CP210x USB to UART Bridge" or similar (the RFD900X uses a standard USB-to-Serial chip). Note the **BUSID** (e.g., `2-3`).
+2. **Bind the device:**
+This step is only required once. It prepares the device for sharing.
+```powershell
+usbipd bind --busid <BUSID>
+
+```
+
+
+
+---
+
+### 3. Attach the Device to WSL
+
+Now, you actually send the connection over to your Ubuntu distro.
+
+1. **Attach the device:**
+```powershell
+usbipd attach --wsl --busid <BUSID>
+
+```
+
+
+*Note: Keep this terminal window open if you didn't use a persistent flag, though usually, it stays attached until unplugged or the WSL instance shuts down.*
+2. **Verify in Ubuntu:**
+Open your **WSL Ubuntu-22.04** terminal and run:
+```bash
+lsusb
+
+```
+
+
+You should see the Silicon Labs / RFD900X device listed there.
+
+---
+
+### 4. Locate the Port in WSL
+
+In Linux, USB-to-Serial devices are mapped to `/dev/tty`. Usually, the first one plugged in is:
+` /dev/ttyUSB0`
+
+**Check permissions:**
+By default, your user might not have permission to read/write to the serial port. Run this in WSL to grant access:
+
+```bash
+sudo chmod 666 /dev/ttyUSB0
+
+```
+
+---
+
+### Common Gotchas
+
+* **WSL Kernel:** If `lsusb` shows the device but your Python script says `/dev/ttyUSB0` doesn't exist, you might be on a very old WSL kernel. Update it by running `wsl --update` in PowerShell.
+* **Automatic Detach:** If you unplug the RFD900X and plug it back in, you must run the `usbipd attach` command again.
+* **Docker:** If you are running your code inside a **Docker container** within WSL, remember to start your container with the `--privileged` flag or by mapping the device specifically:
+`docker run -it --privileged -v /dev/ttyUSB0:/dev/ttyUSB0 my-mavlink-image`

--- a/server/src/controllers/mission.controller.mjs
+++ b/server/src/controllers/mission.controller.mjs
@@ -58,7 +58,7 @@ export async function getMissionByIdController(req, res) {
 		res.status(500).json({ error: error.message });
 	}
 }
-
+// call mavlink sendmission corrdinaytion in this method 
 export async function createMissionController(req, res) {
 	try {
 		const body = req.body || {};

--- a/server/src/controllers/mission.controller.mjs
+++ b/server/src/controllers/mission.controller.mjs
@@ -101,8 +101,7 @@ export async function startMissionController(req, res) {
             return res.status(400).json({ error: 'Start time is required' });
         }
 
-        const bots = await getAssignmentsForMission(missionId);
-        const result = await startMission(missionId, time, bots);
+        const result = await startMission(missionId, time);
 		if (!result.success) return res.status(500).json({ error: result.error || 'Failed to start mission' });
 		res.status(200).json({ message: 'Mission started successfully' });
 	} catch (error) {

--- a/server/src/index.mjs
+++ b/server/src/index.mjs
@@ -2,7 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
-import { sendMissionCoordinates } from "./services/mavlink.service.mjs";
+import { sendMissionCoordinates, handleMavlinkData } from "./services/mavlink.service.mjs";
 import { serverConfig } from './config/server.config.mjs';
 import missionRoutes from './routes/mission.routes.js';
 import botRoutes from './routes/bot.routes.mjs';
@@ -88,8 +88,9 @@ setupSocketHandlers(io);
 setStoreMavlinkDataCallback((data) => storeMavlinkData(data, io));
 
 // Start MAVLink data simulation
-// handleMavlinkData();      // for real data
-simulateMavlinkData();       // for simulated data
+handleMavlinkData();      // for real data
+// simulateMavlinkData();       // for simulated data
+
 
 // Start server
 httpServer.listen(serverConfig.port, () => {
@@ -97,3 +98,5 @@ httpServer.listen(serverConfig.port, () => {
     console.log(`WebSocket server ready`);
     console.log(`Environment: ${serverConfig.environment}`);
 });
+
+    

--- a/server/src/index.mjs
+++ b/server/src/index.mjs
@@ -61,11 +61,11 @@ app.post('/api/send-coordinates', async (req, res) => {
                 lon4: -1193964700
             };
         }
-
-        console.log("Website requested send-coordinates:");
+        botID = 1;
+        console.log("Website requested send-coordinates (botID = 1):");
         console.log(coords);
-
-        await sendMissionCoordinates(coords);
+        
+        await sendMissionCoordinates(botID, coords);
 
         return res.status(200).json({
             success: true,

--- a/server/src/index.mjs
+++ b/server/src/index.mjs
@@ -2,7 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
-
+import { sendMissionCoordinates } from "./services/mavlink.service.mjs";
 import { serverConfig } from './config/server.config.mjs';
 import missionRoutes from './routes/mission.routes.js';
 import botRoutes from './routes/bot.routes.mjs';
@@ -21,6 +21,12 @@ const io = new Server(httpServer, {
     }
 });
 
+
+
+
+
+
+
 // Middleware
 app.use(cors({
     origin: serverConfig.corsOrigin,
@@ -33,6 +39,47 @@ app.use(express.json());
 app.use('/api/missions', missionRoutes);
 app.use('/api/bots', botRoutes);
 app.use('/api/temperature', temperatureRoutes);
+
+
+// ================= ROUTES =================
+
+app.post('/api/send-coordinates', async (req, res) => {
+    try {
+        let coords = req.body;
+
+        if (!coords || Object.keys(coords).length === 0) {
+            console.log("No coordinates provided. Generating random test coordinates...");
+
+            coords = {
+                lat1: 499394300,
+                lon1: -1193964200,
+                lat2: 499394500,
+                lon2: -1193964500,
+                lat3: 499394700,
+                lon3: -1193964300,
+                lat4: 499394900,
+                lon4: -1193964700
+            };
+        }
+
+        console.log("Website requested send-coordinates:");
+        console.log(coords);
+
+        await sendMissionCoordinates(coords);
+
+        return res.status(200).json({
+            success: true,
+            message: "Mission coordinates successfully sent to robot.",
+            sent: coords
+        });
+
+    } catch (error) {
+        console.error("Error sending coordinates:", error);
+        return res.status(500).json({ error: "Failed to send mission coordinates." });
+    }
+});
+
+
 
 // Setup Socket.IO handlers
 setupSocketHandlers(io);

--- a/server/src/services/database.service.mjs
+++ b/server/src/services/database.service.mjs
@@ -380,38 +380,41 @@ export async function startMission(missionId, startTime, bots) {
 			bots
 		);
 
-		// 1. Get the assigned botID
-		const botIDs = getAssignmentsForMission(missionID);
-			// for now let's check to see if botID contains 1.
-			//If so then proceed to the next steps, otherwise skip 2-4.
-
-		// 2. Query the database for mission coordinates using missionId
-		const mission = await getMissionByID(missionId);
-			// mission is a json object.
-			// Inspect the 'areaCoordinates' field it will look like 'areaCoordinates: { east: , west: , north: , south: }'
-			//in the console.log below.
-			console.log(mission)
-			// Store the areaCoordinates in a seperate variable
-
-		// 3. Create a coords object using the variable
-			// Now the areaCoordinates has 2 (lat, lon) pairs that point to 
-			//the top-left corner and bottom-right corner of the area(square).
-			// The top-left corner mapping is (north, west)
-			// The top-right corner mapping is (north, east)
-			// The bottom-right corner mapping is (south, east)
-			// The bottom-right corner mapping is (south, west)
-
-			// Use the information above to construct the object coords below:
-
-	/*const coords = {
-			lat1 ; lon1; 
-			lat2 ; lon2; 
-			lat3; lon3; 
-			lat4; lon4;
-		} */
+	// 1. Get the assigned botIDs
+const botIDs = await getAssignmentsForMission(missionId);
 
 
-		// 4. send coords with botID using the sendMissionCoordinates function you defined.
+if (!botIDs || botIDs.length === 0) {
+    return { success: true }; // nothing to send
+}
+
+// 2. Get mission data
+const missionResult = await getMissionByID(missionId);
+if (!missionResult.success) {
+    throw new Error("Mission not found");
+}
+
+const mission = missionResult.data;
+
+// Parse coordinates safely
+const area = parseJSON(mission.areaCoordinates);
+
+if (!area) {
+    throw new Error("Invalid areaCoordinates");
+}
+
+// 3. Construct coords object (4 corners)
+const coords = {
+    lat1: area.north, lon1: area.west,  // top-left
+    lat2: area.north, lon2: area.east,  // top-right
+    lat3: area.south, lon3: area.east,  // bottom-right
+    lat4: area.south, lon4: area.west   // bottom-left
+};
+
+// 4. Send to each bot
+for (const botID of botIDs) {
+    await sendMissionCoordinates(botID, coords);
+}
 		
 		return { success: true };
 	} catch (error) {

--- a/server/src/services/database.service.mjs
+++ b/server/src/services/database.service.mjs
@@ -1,5 +1,6 @@
 import { pool } from '../config/database.config.mjs';
 import assert from 'assert';
+import { sendMissionCoordinates } from "./mavlink.service.mjs";
 
 // Helper to parse JSON columns safely
 const parseJSON = (value, fallback = null) => {
@@ -378,6 +379,40 @@ export async function startMission(missionId, startTime, bots) {
 			`UPDATE bot SET assignmentStatus = 'active' WHERE botID IN (${bots.map(() => '?').join(',')})`,
 			bots
 		);
+
+		// 1. Get the assigned botID
+		const botIDs = getAssignmentsForMission(missionID);
+			// for now let's check to see if botID contains 1.
+			//If so then proceed to the next steps, otherwise skip 2-4.
+
+		// 2. Query the database for mission coordinates using missionId
+		const mission = await getMissionByID(missionId);
+			// mission is a json object.
+			// Inspect the 'areaCoordinates' field it will look like 'areaCoordinates: { east: , west: , north: , south: }'
+			//in the console.log below.
+			console.log(mission)
+			// Store the areaCoordinates in a seperate variable
+
+		// 3. Create a coords object using the variable
+			// Now the areaCoordinates has 2 (lat, lon) pairs that point to 
+			//the top-left corner and bottom-right corner of the area(square).
+			// The top-left corner mapping is (north, west)
+			// The top-right corner mapping is (north, east)
+			// The bottom-right corner mapping is (south, east)
+			// The bottom-right corner mapping is (south, west)
+
+			// Use the information above to construct the object coords below:
+
+	/*const coords = {
+			lat1 ; lon1; 
+			lat2 ; lon2; 
+			lat3; lon3; 
+			lat4; lon4;
+		} */
+
+
+		// 4. send coords with botID using the sendMissionCoordinates function you defined.
+		
 		return { success: true };
 	} catch (error) {
 		console.error('Error starting mission:', error);

--- a/server/src/services/database.service.mjs
+++ b/server/src/services/database.service.mjs
@@ -1,6 +1,6 @@
 import { pool } from '../config/database.config.mjs';
 import assert from 'assert';
-import { sendMissionCoordinates } from "./mavlink.service.mjs";
+import { sendMissionCoordinates} from "./mavlink.service.mjs";
 
 // Helper to parse JSON columns safely
 const parseJSON = (value, fallback = null) => {
@@ -367,55 +367,46 @@ export async function updateMission(missionId, missionData) {
 	}
 }
 
-export async function startMission(missionId, startTime, bots) {
+export async function startMission(missionId, startTime) {
 	let conn;
 	try {
+		const botIDs = await getAssignmentsForMission(missionId);
+		if (!botIDs || botIDs.length === 0) {
+			throw new Error("No assignments for mission");
+		}
+
+		/* We assume we have only one working bot assigned 'bot 1', so
+		we ignore sending mission coordinates to other bots*/
+		if(botIDs.includes(1)) {
+			const mission = await getMissionByID(missionId);
+			console.log(mission.data.areaCoordinates);
+			const {east, west, north, south} = mission.data.areaCoordinates;
+
+			const coords = {
+				lat1 : north, lon1 : west, 
+				lat2 : north, lon2 : east, 
+				lat3 : south, lon3 : east, 
+				lat4 : south, lon4 : west
+			}
+			
+			const botID = 1;
+
+			// to do: retrieve numTempReading from userSetting in database (not implemented yet)
+			const numTempReadings = 10;
+
+			await sendMissionCoordinates(botID, numTempReadings, coords);
+		}
+
 		conn = await pool.getConnection();
 		await conn.execute(
 			`UPDATE mission SET timeStart = ? WHERE missionID = ?`,
 			[startTime, missionId]
 		);
 		await conn.execute(
-			`UPDATE bot SET assignmentStatus = 'active' WHERE botID IN (${bots.map(() => '?').join(',')})`,
-			bots
+			`UPDATE bot SET assignmentStatus = 'active' WHERE botID IN (${botIDs.map(() => '?').join(',')})`,
+			botIDs
 		);
 
-	// 1. Get the assigned botIDs
-const botIDs = await getAssignmentsForMission(missionId);
-
-
-if (!botIDs || botIDs.length === 0) {
-    return { success: true }; // nothing to send
-}
-
-// 2. Get mission data
-const missionResult = await getMissionByID(missionId);
-if (!missionResult.success) {
-    throw new Error("Mission not found");
-}
-
-const mission = missionResult.data;
-
-// Parse coordinates safely
-const area = parseJSON(mission.areaCoordinates);
-
-if (!area) {
-    throw new Error("Invalid areaCoordinates");
-}
-
-// 3. Construct coords object (4 corners)
-const coords = {
-    lat1: area.north, lon1: area.west,  // top-left
-    lat2: area.north, lon2: area.east,  // top-right
-    lat3: area.south, lon3: area.east,  // bottom-right
-    lat4: area.south, lon4: area.west   // bottom-left
-};
-
-// 4. Send to each bot
-for (const botID of botIDs) {
-    await sendMissionCoordinates(botID, coords);
-}
-		
 		return { success: true };
 	} catch (error) {
 		console.error('Error starting mission:', error);

--- a/server/src/services/mavlink.service.mjs
+++ b/server/src/services/mavlink.service.mjs
@@ -1,12 +1,9 @@
+// mavlinkHandler.mjs
 import { SerialPort } from "serialport";
 import mavlink from "node-mavlink";
 import fetch from "node-fetch";
 
 let storeMavlinkDataCallback = null;
-
-export function setStoreMavlinkDataCallback(callback) {
-    storeMavlinkDataCallback = callback;
-}
 
 const {
   MavLinkPacketSplitter,
@@ -17,47 +14,103 @@ const {
   ardupilotmega,
 } = mavlink;
 
-//create a registry of mappings between msg id and data
+export function setStoreMavlinkDataCallback(callback) {
+    storeMavlinkDataCallback = callback;
+}
+
+// --- START CHANGE: Singleton Serial Port Setup ---
+let serialPort = null;
+
+function getSerialPort() {
+  if (!serialPort) {
+    serialPort = new SerialPort({
+      path: "/dev/ttyUSB0",  // <-- Change this if you use by-id path
+      baudRate: 57600,
+    });
+
+    serialPort.on("open", () => {
+      console.log("Serial port open.");
+    });
+
+    serialPort.on("error", (err) => {
+      console.error("Serial port error:", err);
+    });
+  }
+  return serialPort;
+}
+// --- END CHANGE: Singleton Serial Port Setup ---
+
+
+
+// Registry for message parsing
 const REGISTRY = {
   ...minimal.REGISTRY,
   ...common.REGISTRY,
   ...ardupilotmega.REGISTRY,
 };
 
-// substitute /dev/ttyACM0 with your serial port!
+// --- START CHANGE: Reuse serial port for mission upload ---
+async function sendMissionCoordinates(coords) {
+  const { lat1, lon1, lat2, lon2, lat3, lon3, lat4, lon4 } = coords;
 
+  console.log("Sending mission coordinates to robot...");
+
+  const port = getSerialPort(); // <-- REUSED SINGLETON
+
+  // Helper to send one waypoint
+  const sendWp = (seq, lat, lon) => {
+    const wp = new common.MissionItemInt(
+      1,   // target system id
+      1,   // target component id
+      seq, // waypoint index
+      0,   // frame (0 = global)
+      16,  // command (16 = NAV_WAYPOINT)
+      0,   // current
+      1,   // autocontinue
+      0, 0, 0, 0,  
+      lat, // latitude * 1e7
+      lon, // longitude * 1e7
+      50   // altitude 50m
+    );
+
+    const buffer = mavEncoder.pack(wp);
+    port.write(buffer);
+    console.log(`Sent WP ${seq}: lat=${lat}, lon=${lon}`);
+  };
+
+  // Send 4 mission points
+  sendWp(0, lat1, lon1);
+  sendWp(1, lat2, lon2);
+  sendWp(2, lat3, lon3);
+  sendWp(3, lat4, lon4);
+
+  console.log("All mission coordinates sent.");
+}
+// --- END CHANGE: Reuse serial port for mission upload ---
+
+// --- START CHANGE: Reuse serial port for reading MAVLink ---
 function handleMavlinkData() {
+  const port = getSerialPort(); // <-- REUSED SINGLETON
 
-  //serialPort.close();
-  const portSerialNumber = "/dev/ttyUSB0";
+  // constructing a reader that will emit each packet separately
+  const mavlinkRead = port
+    .pipe(new mavlink.MavLinkPacketSplitter())
+    .pipe(new mavlink.MavLinkPacketParser());
 
-  const serialPort = new SerialPort({
-    path: portSerialNumber,
-    baudRate: 57600,
-  });
+  console.log("MAVLink reader initialized.");
 
-  //constructing a reader that will emit each packet separately
-  const mavlinkRead = serialPort
-    .pipe(new MavLinkPacketSplitter())
-    .pipe(new MavLinkPacketParser());
-  console.log("hello from mavlink");
-  //storeMavlinkData(1);
-
-  //setup mavlink to listen for packets
-  mavlinkRead.on("data", async (packet) => {
-    console.log("Packet received");
+  mavlinkRead.on("data", (packet) => {
     const clazz = REGISTRY[packet.header.msgid];
     if (clazz) {
       const data = packet.protocol.data(packet.payload, clazz);
       data.timeBootMs = new Date();
-      //process the parsed data based on type
       switch (clazz.MSG_NAME) {
         case "GLOBAL_POSITION_INT":
-          console.log("GLOBAL_POSITION_INT");
+          console.log("GLOBAL_POSITION_INT received");
           processGlobalPositionMessage(data);
           break;
         case "NAMED_VALUE_FLOAT":
-          console.log("NAMED_VALUE_FLOAT");
+          console.log("NAMED_VALUE_FLOAT received");
           processTemperatureMessage(data);
           break;
         default:
@@ -66,20 +119,13 @@ function handleMavlinkData() {
     }
   });
 
-  mavlinkRead.on("error", (error) => {
-    console.error("Error reading Mavlink data:", error);
+  mavlinkRead.on("error", (err) => {
+    console.error("Error reading MAVLink:", err);
   });
 }
+// --- END CHANGE: Reuse serial port for reading MAVLink ---
 
-/*
-  Function to simulate incoming temp/position/battery data, trying to copy the format of data objects that previous devs were processing in below functions (processTemperatureMessage and processGlobalPositionMessage, which I have mostly not touched since then). I assumed that the data format for temp and position data will stay the same as Apr 2024, because I was told that this code worked during the demo last year.
-
-  This function simulates 
-    1) Every 5 seconds, either position or temperature data with a 50/50 chance, coming in from a bot with random ID between 1-5    
-    2) Every 15 seconds, data for percentage battery remaining for all 5 bots. 
-    
-  NOTE: data format for simulated battery data is arbitrary; i.e. the keys do not correspond to actual incoming data, because battery percentage is new and I do not yet know the format in which battery % will be sent by the bot. Once format is finalized, function processBatteryMessage() as well as the 'battery' table in DB must both be changed, and the battery simulation part of the function will break unless also changed accordingly.
-*/
+// Simulate data (unchanged)
 function simulateMavlinkData() {
   console.log("Simulating MAVLink data...");
   const NUM_SIMULATED_BOTS = 3;
@@ -221,5 +267,4 @@ function processBatteryMessage(data) {
   // storeMavlinkData(batteryData);
 }
 
-
-export { handleMavlinkData, simulateMavlinkData };
+export { handleMavlinkData, simulateMavlinkData, sendMissionCoordinates };

--- a/server/src/services/mavlink.service.mjs
+++ b/server/src/services/mavlink.service.mjs
@@ -1,6 +1,7 @@
 // mavlinkHandler.mjs
 import { SerialPort } from "serialport";
 import mavlink from "node-mavlink";
+import { MavLinkProtocolV2, send} from 'node-mavlink';
 import fetch from "node-fetch";
 
 let storeMavlinkDataCallback = null;
@@ -49,41 +50,90 @@ const REGISTRY = {
   ...ardupilotmega.REGISTRY,
 };
 
-// --- START CHANGE: Reuse serial port for mission upload ---
-async function sendMissionCoordinates(botID, coords) {
+///
+function encodeMissionData(numTempReadings , coords) {
+
   const { lat1, lon1, lat2, lon2, lat3, lon3, lat4, lon4 } = coords;
 
-  console.log("Sending mission coordinates to robot...");
+  const lats = [lat1,lat2,lat3,lat4];
+  const lons = [lon1,lon2,lon3,lon4];
 
-  const port = getSerialPort(); // <-- REUSED SINGLETON
+  // Create a buffer for the full MAVLink payload (249 bytes)
+  const buffer = Buffer.alloc(249);
+  let offset = 0;
 
-  // Helper to send one waypoint
-  const sendWp = (seq, lat, lon) => {
-    const wp = new common.MissionItemInt();
-      wp.target_system = 1;   // target system id
-      wp.target_componenet = 1;   // target component id
-      wp.seq = seq; // waypoint index
-      wp.frame = 0;   // frame (0 = global)
-      wp.command = 16;  // command (16 = NAV_WAYPOINT)
-      wp.current = 0;   // current
-      wp.autocontinue = 1;   // autocontinue
-      wp.param1 = botID; wp.param2 =  0; wp.param3 = 0; wp.param4 = 0;  
-      wp.x = lat * 1e7; // latitude * 1e7
-      wp.y = lon * 1e7; // longitude * 1e7
-      wp.z = 50.0;   // altitude 50m
-    
-      
-    send(port, wp, new MavLinkProtocolV2());
-    console.log(`Sent WP ${seq}: lat=${lat}, lon=${lon}`);
-  };
+  // Pack number of temperature readings
+  buffer.writeInt32LE(numTempReadings, offset);
+  offset += 4;
 
-  // Send 4 mission points
-  sendWp(0, lat1, lon1);
-  sendWp(1, lat2, lon2);
-  sendWp(2, lat3, lon3);
-  sendWp(3, lat4, lon4);
+  // Pack Latitudes (Int32, Little Endian)
+  lats.forEach(lat => {
+      buffer.writeInt32LE((lat*1e7), offset);
+      offset += 4;
+  });
 
-  console.log("All mission coordinates sent.");
+  // Pack Longitudes (Int32, Little Endian)
+  lons.forEach(lon => {
+      buffer.writeInt32LE(lon*1e7, offset);
+      offset += 4;
+  });
+
+  // Return the 249-byte array ready for MAVLink
+  return Array.from(buffer);
+}
+///
+
+// --- START CHANGE: Reuse serial port for mission upload ---
+let receivedAck = false;
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function sendMissionCoordinates(botId, numTempReadings , coords) {
+///
+  const payload = encodeMissionData(numTempReadings , coords);
+  
+  const msg = new common.LoggingDataAcked();
+    msg.target_system = botId;
+    msg.target_component = 0;
+    msg.seq = 0;
+    msg.length = 249;
+    msg.first_message_offset = 0;
+    msg.data = payload;
+
+  console.log("Sending mission data to bot " + botId + "...");
+
+  const port = getSerialPort();
+
+  await send(port, msg, new MavLinkProtocolV2());
+
+  let timer = 0;
+  const timeLimit = 5;  // maximum wait time(in seconds) to receive acknowledgement
+  let countSend = 1;
+  const sendLimit = 3;  // limit of amount time for data to be sent until acknowledgement is received
+  while(receivedAck == false && countSend <= sendLimit) {
+    while(receivedAck == false && timer <= timeLimit) {
+      await sleep(1000);
+      timer++;
+    }
+    timer = 0; // reset the timer
+
+    if (receivedAck == true) {
+      console.log("Received acknowledgement from bot", botId);
+    }
+    else {
+      console.error("Did not receive acknowledgement from bot", botId);
+      console.log("Trying again...");
+      await send(port, msg, new MavLinkProtocolV2());
+    }
+    countSend++;
+  }
+  if(receivedAck == false) {
+    throw new Error("Failed to receive acknowledgement from bot " + botId + 
+      " after trying " + sendLimit + " times");
+  }
+  receivedAck = false;
 }
 // --- END CHANGE: Reuse serial port for mission upload ---
 
@@ -111,6 +161,10 @@ function handleMavlinkData() {
         case "NAMED_VALUE_FLOAT":
           console.log("NAMED_VALUE_FLOAT received");
           processTemperatureMessage(data);
+          break;
+        case "LOGGING_ACK":
+          console.log("LOGGING_ACK received");
+          receivedAck = true;
           break;
         default:
           console.log("Unknown message type:", clazz.MSG_NAME);

--- a/server/src/services/mavlink.service.mjs
+++ b/server/src/services/mavlink.service.mjs
@@ -50,7 +50,7 @@ const REGISTRY = {
 };
 
 // --- START CHANGE: Reuse serial port for mission upload ---
-async function sendMissionCoordinates(coords) {
+async function sendMissionCoordinates(botID, coords) {
   const { lat1, lon1, lat2, lon2, lat3, lon3, lat4, lon4 } = coords;
 
   console.log("Sending mission coordinates to robot...");
@@ -59,22 +59,21 @@ async function sendMissionCoordinates(coords) {
 
   // Helper to send one waypoint
   const sendWp = (seq, lat, lon) => {
-    const wp = new common.MissionItemInt(
-      1,   // target system id
-      1,   // target component id
-      seq, // waypoint index
-      0,   // frame (0 = global)
-      16,  // command (16 = NAV_WAYPOINT)
-      0,   // current
-      1,   // autocontinue
-      0, 0, 0, 0,  
-      lat, // latitude * 1e7
-      lon, // longitude * 1e7
-      50   // altitude 50m
-    );
-
-    const buffer = mavEncoder.pack(wp);
-    port.write(buffer);
+    const wp = new common.MissionItemInt();
+      wp.target_system = 1;   // target system id
+      wp.target_componenet = 1;   // target component id
+      wp.seq = seq; // waypoint index
+      wp.frame = 0;   // frame (0 = global)
+      wp.command = 16;  // command (16 = NAV_WAYPOINT)
+      wp.current = 0;   // current
+      wp.autocontinue = 1;   // autocontinue
+      wp.param1 = botID; wp.param2 =  0; wp.param3 = 0; wp.param4 = 0;  
+      wp.x = lat * 1e7; // latitude * 1e7
+      wp.y = lon * 1e7; // longitude * 1e7
+      wp.z = 50.0;   // altitude 50m
+    
+      
+    send(port, wp, new MavLinkProtocolV2());
     console.log(`Sent WP ${seq}: lat=${lat}, lon=${lon}`);
   };
 


### PR DESCRIPTION
## Summary
Feature send mission allows for forward communication from the host to the [EMBR](https://github.com/HEATRobotics/EMBR-Bot/tree/main) bot using [mavlink message](https://mavlink.io/en/messages/common.html#LOGGING_DATA). The communication in particular sends mission data including **number of temperatures readings** required from the bot and **mission area coordinate**(rectangle).


## Linked Pull Request
This PR depends on HEATRoboics/EMBR-Bot#51 (the bot update).


## Related Task
Closes [Notion Task](https://www.notion.so/Send-Receive-area-to-cover-and-temp-threshold-from-website-to-robot-27d05a18706d80429db7cf84b28ac71f?source=copy_link)

---

## Type of Change
Select all that apply:

- [x] 🆕 Feature  
- [ ] 🐞 Bug Fix  
- [x] 🧹 Refactor  
- [x] 🧾 Documentation Update  
- [ ] 🧰 Maintenance / Tooling  
- [ ] Other (specify below)

---

## 📄 Documentation
- [ ] All of the following applicable documentation changes were added
  - [ ] How to connect the new device and wiring
  - [ ] Links to external documentation on the device
  - [x] Any other setup or important information
- [ ] No documentation changes required  

---

## 🧪 Testing
- Tested mavlink message parameter encoder with range of values
- Tested Acknowledge timeout and retries


---

## ✅ Pre-Merge Checklist

* [x] PR started as a **Draft**
* [x] Linked to correct **Notion Task**
* [x] Branch includes updated documentation
* [ ] Code reviewed by peer
* [ ] Ready for final review by Software Lead
* [ ] All tests and builds pass
* [ ] Notion task updated to **Ready for Review**

---

## 🧾 Notes (Optional)
- This feature currently works with one active(real) bot with the required botId 1. 
- To extend the feature to multiple bots,
-- update sendMissionCoordinates to allow bots with botId not equal to 1.
-- update startMission to call sendMissionCoordinates asnychronously and handle each promise seperately.
